### PR TITLE
Rework of the vnet part

### DIFF
--- a/share/pot/stop.sh
+++ b/share/pot/stop.sh
@@ -19,6 +19,7 @@ _js_stop()
 	if _is_pot_running $_pname ; then
 		if grep -q vnet $_jdir/conf/jail.conf ; then
 			_epair=$(jexec $_pname ifconfig | grep ^epair | cut -d':' -f1)
+			cp -v $_jdir/conf/jail.conf.orig $_jdir/conf/jail.conf
 		fi
 		jail -r $_pname
 		if [ -n "$_epair" ]; then


### PR DESCRIPTION
This patch solves the issue #1 

The epair interface is injected in the `jail.conf` file
The network interface configuration is dynamically added to `rc.conf` before starting; default gateway as well.
During the stop, the original `jail.conf` is restored.