### PR TITLE
Switch code blocks' highlighting to "console"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The project was presented at FOSDEM 2018: [video mp4](https://video.fosdem.org/2
 ### Installation
 
 A package is available, even if it could be a bit outdated. You can install it via:
-```sh
+```console
 # pkg install pot
 ```
 
@@ -29,7 +29,7 @@ Or you can install pot manually:
 Before to run any initialization, I suggest to copy `etc/pot/pot.defaul.conf` in `etc/pot/pot.conf` and set all variables in accord to your system.
 
 When the pot'r configuration file is ready, the initialization can be performed (root privileges are needed):
-```sh
+```console
 # pot init
 # pot create-base -r 11.1
 ```
@@ -47,12 +47,12 @@ Example2: you can create a 10.4 base on a FreeBSD 10.4 machine, but not a 11.1 b
 ### Create your first pot
 
 Now you can create a pot using the command:
-```sh
+```console
 # pot create -p potname -b 11.1
 ```
 
 To start and access it, you can used the command:
-```sh
+```console
 # pot run potname
 ```
 
@@ -62,7 +62,7 @@ This command will start the pot and spawn a `tcsh` shell in it.
 
 pot command line provides inline help:
 
-```sh
+```console
 # pot help
 # pot help create
 ```


### PR DESCRIPTION
`console` highlighter should be used for code blocks with 
interactive sessions. Using `sh` results in root commands 
being highlighted as comments.

For example:

- sh:

  ```sh
  # ls
  Documents
  ```

- console:

  ```console
  # ls
  Documents
  ```