### PR TITLE
Add support to environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- set-env: new command to add environment variable to a pot
 - network-type private-bridge: add a new network layout, to provide private bridges for a group of pots
 - create-private-bridge: new subcommand to define and create a private-bridge
 - create: add option -B, to provide the bridge name if network-type is private-bridge
@@ -13,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - prepare: add option -B, to provide the bridge name if network-type is private-bridge
 - destroy: add option -B, to provide a way to destroy a bridge
 - Image Guide: added a guide about how to create an Image of a pot
+
+### Changed
+- flavorable commands: extend support to set-cmd and set-env
 
 ## [0.9.2] 2019-08-25
 ### Added

--- a/bin/pot
+++ b/bin/pot
@@ -97,6 +97,7 @@ Commands:
 	set-rss -- Set a resource constraint
 	get-rss -- Get the current resource usage
 	set-cmd -- Set the command to start the pot
+	set-env -- Set environment variabls inside a pot
 	set-attr -- Set a pot's attribute
 	get-attr -- Get a pot's attribute
 	export-ports -- Let export tcp ports
@@ -159,7 +160,7 @@ case "${CMD}" in
 	create-base|create-fscomp|create|create-dns|\
 	create-private-bridge|\
 	copy-in|mount-in|prune|\
-	destroy|add-dep|set-rss|get-rss|set-cmd|\
+	destroy|add-dep|set-rss|get-rss|set-cmd|set-env|\
 	export|import|prepare|\
 	export-ports|set-attribute|get-attribute|\
 	start|stop|term|\

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -662,7 +662,7 @@ _is_cmd_flavorable()
 	case $_cmd in
 		add-dep|set-attribute|\
 		copy-in|mount-in|\
-		set-rss|export-ports|
+		set-rss|export-ports|\
 		set-cmd|set-env)
 			return 0
 			;;

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -662,7 +662,8 @@ _is_cmd_flavorable()
 	case $_cmd in
 		add-dep|set-attribute|\
 		copy-in|mount-in|\
-		set-rss|export-ports)
+		set-rss|export-ports|
+		set-cmd|set-env)
 			return 0
 			;;
 	esac

--- a/share/pot/set-env.sh
+++ b/share/pot/set-env.sh
@@ -49,7 +49,8 @@ pot-set-env()
 				set-env-help
 				${EXIT} 1
 			fi
-			echo "\"$OPTARG\"" >> $_tmpfile
+			_tmp="$( echo "$OPTARG" | sed 's%"%\\"%g' )"
+			echo "\"$_tmp\"" >> $_tmpfile
 			_env=1
 			;;
 		p)

--- a/share/pot/set-env.sh
+++ b/share/pot/set-env.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+:
+
+# shellcheck disable=SC2039
+set-env-help() {
+	echo "pot set-env [-hv] -p pot -E env"
+	echo '  -h print this help'
+	echo '  -v verbose'
+	echo '  -p pot : the working pot'
+	echo '  -E var=value : the variable and the value to be added'
+	echo '     this option can be repeated more than once'
+}
+
+# $1 pot
+# $2 env
+_set_environment()
+{
+	# shellcheck disable=SC2039
+	local _pname _tmpfile _cfile
+	_pname="$1"
+	_tmpfile="$2"
+	_cfile=$POT_FS_ROOT/jails/$_pname/conf/pot.conf
+	sed -i '' -e "/^pot.env=.*/d" "$_cfile"
+	cat "$_tmpfile" | sed 's/.*/pot.env=&/g' >> "$_cfile"
+}
+
+# shellcheck disable=SC2039
+pot-set-env()
+{
+	local _pname _env _tmpfile
+	_env=
+	_pname=
+	_tmpfile="/tmp/pot-set-env"
+	OPTIND=1
+	while getopts "hvp:E:" _o ; do
+		case "$_o" in
+		h)
+			set-env-help
+			${EXIT} 0
+			;;
+		v)
+			_POT_VERBOSITY=$(( _POT_VERBOSITY + 1))
+			;;
+		E)
+			if [ "$OPTARG" = "${OPTARG#*=}" ]; then
+				# the argument doesn't have an equal sign
+				_error "$OPTARG not in a valid form"
+				_error "VARIABLE=value is accetped"
+				set-env-help
+				${EXIT} 1
+			fi
+			echo "\"$OPTARG\"" >> $_tmpfile
+			_env=1
+			;;
+		p)
+			_pname="$OPTARG"
+			;;
+		?)
+			set-env-help
+			${EXIT} 1
+		esac
+	done
+
+	if [ -z "$_pname" ]; then
+		_error "A pot name is mandatory"
+		set-env-help
+		${EXIT} 1
+	fi
+	if [ -z "$_env" ]; then
+		_error "A command is mandatory"
+		set-env-help
+		${EXIT} 1
+	fi
+	if ! _is_pot "$_pname" ; then
+		_error "pot $_pname is not valid"
+		set-env-help
+		${EXIT} 1
+	fi
+	if ! _is_uid0 ; then
+		${EXIT} 1
+	fi
+	_set_environment "$_pname" "$_tmpfile"
+	rm "$_tmpfile"
+}

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -258,6 +258,21 @@ _js_norc()
 	chmod a+x "${POT_FS_ROOT}/jails/$_pname/m/tmp/tinirc"
 }
 
+_js_env()
+{
+	# shellcheck disable=SC2039
+	local _pname _shfile _cfile
+	_pname="$1"
+	_cfile="${POT_FS_ROOT}/jails/$_pname/conf/pot.conf"
+	_shfile="/tmp/pot_environment_$_pname.sh"
+	grep '^pot.env=' "$_cfile" | sed 's/^pot.env=/export /g' > "$_shfile"
+	if [ "$(_get_conf_var "$_pname" "pot.attr.no-rc-script")" = "YES" ]; then
+		cat "$_shfile" >> "${POT_FS_ROOT}/jails/$_pname/m/tmp/tinirc"
+	else
+		cp "$_shfile" "${POT_FS_ROOT}/jails/$_pname/m/tmp/environment.sh"
+	fi
+}
+
 _bg_start()
 {
 	# shellcheck disable=SC2039
@@ -325,6 +340,7 @@ _js_start()
 		_js_export_ports "$_pname"
 		;;
 	esac
+	_js_env "$_pname"
 	if [ "$(_get_conf_var "$_pname" "pot.attr.no-rc-script")" = "YES" ]; then
 		_js_norc "$_pname"
 		_cmd=/tmp/tinirc

--- a/share/zsh/site-functions/_pot
+++ b/share/zsh/site-functions/_pot
@@ -231,6 +231,13 @@ _pot() {
 						'-p[pot name]:pot name:_pot_pots' \
 						'-c[command]::_normal'
 					;;
+				set-env)
+					_arguments \
+						'-h[Show help]' \
+						'-v[Verbose output]' \
+						'-p[pot name]:pot name:_pot_pots' \
+						'*-E[variable list]::_normal'
+					;;
 				set-attr|set-attribute)
 					_arguments \
 						'-h[Show help]' \
@@ -368,6 +375,7 @@ _pot_cmds() {
 	'set-rss:Set a resource constraint to a pot'
 	'get-rss:Get the current resource usage'
 	'set-cmd:Set the initial command of a pot'
+	'set-env:Set environment variables inside a pot'
 	'set-attr:Set the value of a pot attribute'
 	'set-attribute:Set the value of a pot attribute'
 	'get-attr:Get the value of a pot attribute'

--- a/tests/set-env1.sh
+++ b/tests/set-env1.sh
@@ -189,6 +189,19 @@ test_pot_set_env_046()
 	assertEquals "_tmpfile" '"VAR2=?h* "' "$(sed '2!d' /tmp/pot-set-env)"
 }
 
+test_pot_set_env_027()
+{
+	pot-set-env -p test-pot -E VAR='value1 "value2"'
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
+	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR=value1 \"value2\""' "$(sed '1!d' /tmp/pot-set-env)"
+}
+
 test_pot_set_env_060()
 {
 	pot-set-env -p test-pot -E "VAR=value1 value2"

--- a/tests/set-env1.sh
+++ b/tests/set-env1.sh
@@ -1,0 +1,258 @@
+#!/bin/sh
+
+# system utilities stubs
+
+# UUT
+. ../share/pot/set-env.sh
+
+# common stubs
+. common-stub.sh
+
+# app specific stubs
+set-env-help()
+{
+	__monitor HELP "$@"
+}
+
+rm()
+{
+	__monitor RM "$@"
+}
+
+_set_environment()
+{
+	__monitor SETENV "$@"
+}
+
+test_pot_set_env_001()
+{
+	pot-set-env
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "1" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
+
+	setUp
+	pot-set-env -bv
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
+
+	setUp
+	pot-set-env -b bb
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
+
+	setUp
+	pot-set-env -h
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
+}
+
+test_pot_set_env_002()
+{
+	pot-set-env -p test-pot
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "1" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
+
+	setUp
+	pot-set-env -E VAR=value
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "1" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
+}
+
+test_pot_set_env_020()
+{
+	pot-set-env -p test-no-pot -E VAR=value
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "1" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
+}
+
+test_pot_set_env_021()
+{
+	pot-set-env -p test-pot -E NOVAR
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "2" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "0" "$SETENV_CALLS"
+}
+
+test_pot_set_env_040()
+{
+	pot-set-env -p test-pot -E VAR=value
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
+	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR=value"' "$(sed '1!d' /tmp/pot-set-env)"
+}
+
+test_pot_set_env_041()
+{
+	pot-set-env -p test-pot -E VAR=value -E VAR2=value2
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
+	assertEquals "_tmpfile length" "2" "$( awk 'END {print NR}' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR=value"' "$(sed '1!d' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR2=value2"' "$(sed '2!d' /tmp/pot-set-env)"
+}
+
+test_pot_set_env_042()
+{
+	pot-set-env -p test-pot -E VAR="value1 value2"
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
+	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR=value1 value2"' "$(sed '1!d' /tmp/pot-set-env)"
+}
+
+test_pot_set_env_043()
+{
+	pot-set-env -p test-pot -E VAR="value1 value2" -E VAR2=value3
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
+	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEquals "_tmpfile length" "2" "$( awk 'END {print NR}' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR=value1 value2"' "$(sed '1!d' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR2=value3"' "$(sed '2!d' /tmp/pot-set-env)"
+}
+
+test_pot_set_env_044()
+{
+	pot-set-env -p test-pot -E EMPTYVAR=
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
+	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"EMPTYVAR="' "$(sed '1!d' /tmp/pot-set-env)"
+}
+
+test_pot_set_env_045()
+{
+	pot-set-env -p test-pot -E VAR="12*"
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
+	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR=12*"' "$(sed '1!d' /tmp/pot-set-env)"
+}
+
+test_pot_set_env_046()
+{
+	pot-set-env -p test-pot -E VAR='12*' -E 'VAR2=?h* '
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
+	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEquals "_tmpfile length" "2" "$( awk 'END {print NR}' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR=12*"' "$(sed '1!d' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR2=?h* "' "$(sed '2!d' /tmp/pot-set-env)"
+}
+
+test_pot_set_env_060()
+{
+	pot-set-env -p test-pot -E "VAR=value1 value2"
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
+	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR=value1 value2"' "$(sed '1!d' /tmp/pot-set-env)"
+}
+
+test_pot_set_env_061()
+{
+	pot-set-env -p test-pot -E VAR="value1 value2"
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
+	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR=value1 value2"' "$(sed '1!d' /tmp/pot-set-env)"
+}
+
+test_pot_set_env_062()
+{
+	pot-set-env -p test-pot -E 'VAR=value1 value2'
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
+	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR=value1 value2"' "$(sed '1!d' /tmp/pot-set-env)"
+}
+
+test_pot_set_env_063()
+{
+	pot-set-env -p test-pot -E VAR='value1 value2'
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_environment calls" "1" "$SETENV_CALLS"
+	assertEquals "_set_environment arg1" "test-pot" "$SETENV_CALL1_ARG1"
+	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-env)"
+	assertEquals "_tmpfile" '"VAR=value1 value2"' "$(sed '1!d' /tmp/pot-set-env)"
+}
+
+setUp()
+{
+	common_setUp
+	HELP_CALLS=0
+	SETENV_CALLS=0
+	/bin/rm -f /tmp/pot-set-env
+}
+
+tearDown()
+{
+	/bin/rm -f /tmp/pot-set-env
+}
+
+
+. shunit/shunit2

--- a/tests/set-env2.sh
+++ b/tests/set-env2.sh
@@ -87,6 +87,16 @@ EOF_SETENV
 	assertEquals "pot.env args" 'pot.env="VAR2=?h* "' "$(grep "^pot.env=\"VAR2=" /tmp/jails/test-pot/conf/pot.conf)"
 }
 
+test_set_environment_007()
+{
+	cat > /tmp/pot-set-env << EOF_SETENV
+"VAR=value1 \"value2\""
+EOF_SETENV
+	_set_environment test-pot /tmp/pot-set-env
+	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env args" 'pot.env="VAR=value1 \"value2\""' "$(grep "^pot.env=\"VAR=" /tmp/jails/test-pot/conf/pot.conf)"
+}
+
 setUp()
 {
 	conf_setUp

--- a/tests/set-env2.sh
+++ b/tests/set-env2.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+# system utilities stubs
+
+# UUT
+. ../share/pot/set-env.sh
+. ../share/pot/common.sh
+
+# common stubs
+. conf-stub.sh
+
+test_set_environment_000()
+{
+	cat > /tmp/pot-set-env << EOF_SETENV
+"VAR=value"
+EOF_SETENV
+	_set_environment test-pot /tmp/pot-set-env
+
+	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env args" 'pot.env="VAR=value"' "$(grep ^pot.env /tmp/jails/test-pot/conf/pot.conf)"
+}
+
+test_set_environment_001()
+{
+	cat > /tmp/pot-set-env << EOF_SETENV
+"VAR=value"
+"VAR2=value2"
+EOF_SETENV
+	_set_environment test-pot /tmp/pot-set-env
+
+	assertEquals "pot.env lines" "2" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env args" 'pot.env="VAR=value"' "$(grep "^pot.env=\"VAR=" /tmp/jails/test-pot/conf/pot.conf)"
+	assertEquals "pot.env args" 'pot.env="VAR2=value2"' "$(grep "^pot.env=\"VAR2=" /tmp/jails/test-pot/conf/pot.conf)"
+}
+
+test_set_environment_002()
+{
+	cat > /tmp/pot-set-env << EOF_SETENV
+"VAR=value1 value2"
+EOF_SETENV
+	_set_environment test-pot /tmp/pot-set-env
+	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env args" 'pot.env="VAR=value1 value2"' "$(grep ^pot.env /tmp/jails/test-pot/conf/pot.conf)"
+}
+
+test_set_environment_003()
+{
+	cat > /tmp/pot-set-env << EOF_SETENV
+"VAR=value1 value2"
+"VAR2=value3"
+EOF_SETENV
+	_set_environment test-pot /tmp/pot-set-env
+	assertEquals "pot.env lines" "2" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env args" 'pot.env="VAR=value1 value2"' "$(grep "^pot.env=\"VAR=" /tmp/jails/test-pot/conf/pot.conf)"
+	assertEquals "pot.env args" 'pot.env="VAR2=value3"' "$(grep "^pot.env=\"VAR2=" /tmp/jails/test-pot/conf/pot.conf)"
+}
+
+test_set_environment_004()
+{
+	cat > /tmp/pot-set-env << EOF_SETENV
+"EMPTYVAR="
+EOF_SETENV
+	_set_environment test-pot /tmp/pot-set-env
+	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env args" 'pot.env="EMPTYVAR="' "$(grep ^pot.env /tmp/jails/test-pot/conf/pot.conf)"
+}
+
+test_set_environment_005()
+{
+	cat > /tmp/pot-set-env << EOF_SETENV
+"VAR=12*"
+EOF_SETENV
+	_set_environment test-pot /tmp/pot-set-env
+	assertEquals "pot.env lines" "1" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env args" 'pot.env="VAR=12*"' "$(grep ^pot.env /tmp/jails/test-pot/conf/pot.conf)"
+}
+
+test_set_environment_006()
+{
+	cat > /tmp/pot-set-env << EOF_SETENV
+"VAR=12*"
+"VAR2=?h* "
+EOF_SETENV
+	_set_environment test-pot /tmp/pot-set-env
+	assertEquals "pot.env lines" "2" "$(grep -c "^pot.env=" /tmp/jails/test-pot/conf/pot.conf)" 
+	assertEquals "pot.env args" 'pot.env="VAR=12*"' "$(grep "^pot.env=\"VAR=" /tmp/jails/test-pot/conf/pot.conf)"
+	assertEquals "pot.env args" 'pot.env="VAR2=?h* "' "$(grep "^pot.env=\"VAR2=" /tmp/jails/test-pot/conf/pot.conf)"
+}
+
+setUp()
+{
+	conf_setUp
+}
+
+tearDown()
+{
+	conf_tearDown
+	/bin/rm -f /tmp/pot-set-env
+}
+. shunit/shunit2

--- a/tests/start3.sh
+++ b/tests/start3.sh
@@ -35,6 +35,9 @@ test_js_env_020()
 	assertEquals "env script length" "1" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
 	assertEquals "export line" "1" "$( grep -F -c 'export "VAR=value"' /tmp/pot_environment_test-pot.sh)"
 	assertEquals "export line2" "0" "$( grep -F -c 'export "VAR2=' /tmp/pot_environment_test-pot.sh)"
+
+	. /tmp/pot_environment_test-pot.sh
+	assertEquals "export validation" "$VAR" "value"
 }
 
 test_js_env_021()
@@ -45,6 +48,10 @@ test_js_env_021()
 	assertEquals "env script length" "2" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
 	assertEquals "export line" "1" "$( grep -F -c 'export "VAR=value"' /tmp/pot_environment_test-pot.sh)"
 	assertEquals "export line" "1" "$( grep -F -c 'export "VAR2=value2"' /tmp/pot_environment_test-pot.sh)"
+
+	. /tmp/pot_environment_test-pot.sh
+	assertEquals "export validation" "$VAR" "value"
+	assertEquals "export validation" "$VAR2" "value2"
 }
 
 test_js_env_022()
@@ -54,6 +61,9 @@ test_js_env_022()
 	assertTrue "env script exists" "[ -e /tmp/pot_environment_test-pot.sh ]"
 	assertEquals "env script length" "1" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
 	assertEquals "export line" "1" "$( grep -F -c 'export "VAR=value1 value2"' /tmp/pot_environment_test-pot.sh)"
+
+	. /tmp/pot_environment_test-pot.sh
+	assertEquals "export validation" "$VAR" "value1 value2"
 }
 
 test_js_env_023()
@@ -64,6 +74,10 @@ test_js_env_023()
 	assertEquals "env script length" "2" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
 	assertEquals "export line" "1" "$( grep -F -c 'export "VAR=value1 value2"' /tmp/pot_environment_test-pot.sh)"
 	assertEquals "export line" "1" "$( grep -F -c 'export "VAR2=value3"' /tmp/pot_environment_test-pot.sh)"
+
+	. /tmp/pot_environment_test-pot.sh
+	assertEquals "export validation" "$VAR" "value1 value2"
+	assertEquals "export validation" "$VAR2" "value3"
 }
 
 test_js_env_024()
@@ -73,6 +87,9 @@ test_js_env_024()
 	assertTrue "env script exists" "[ -e /tmp/pot_environment_test-pot.sh ]"
 	assertEquals "env script length" "1" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
 	assertEquals "export line" "1" "$( grep -F -c 'export "EMPTYVAR="' /tmp/pot_environment_test-pot.sh)"
+
+	. /tmp/pot_environment_test-pot.sh
+	assertEquals "export validation" "$EMPTYVAR" ""
 }
 
 test_js_env_025()
@@ -82,6 +99,9 @@ test_js_env_025()
 	assertTrue "env script exists" "[ -e /tmp/pot_environment_test-pot.sh ]"
 	assertEquals "env script length" "1" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
 	assertEquals "export line" "1" "$( grep -F -c 'export "VAR=12*"' /tmp/pot_environment_test-pot.sh)"
+
+	. /tmp/pot_environment_test-pot.sh
+	assertEquals "export validation" "$VAR" "12*"
 }
 
 test_js_env_026()
@@ -92,6 +112,22 @@ test_js_env_026()
 	assertEquals "env script length" "2" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
 	assertEquals "export line" "1" "$( grep -F -c 'export "VAR=12*"' /tmp/pot_environment_test-pot.sh)"
 	assertEquals "export line" "1" "$( grep -F -c 'export "VAR2=?h* "' /tmp/pot_environment_test-pot.sh)"
+
+	. /tmp/pot_environment_test-pot.sh
+	assertEquals "export validation" "$VAR" "12*"
+	assertEquals "export validation" "$VAR2" "?h* "
+}
+
+test_js_env_027()
+{
+	pot-set-env -p test-pot -E 'VAR=value1 "value2"'
+	_js_env test-pot
+	assertTrue "env script exists" "[ -e /tmp/pot_environment_test-pot.sh ]"
+	assertEquals "env script length" "1" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR=value1 \"value2\""' /tmp/pot_environment_test-pot.sh)"
+
+	. /tmp/pot_environment_test-pot.sh
+	assertEquals "export validation" 'value1 "value2"' "$VAR"
 }
 
 test_js_env_040()

--- a/tests/start3.sh
+++ b/tests/start3.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+
+# system utilities stubs
+pfctl()
+{
+	__monitor PFCTL "$@"
+}
+
+# UUT
+. ../share/pot/start.sh
+
+# common stubs
+. ../share/pot/common.sh
+. ../share/pot/set-env.sh
+. common-stub.sh
+. conf-stub.sh
+
+cp()
+{
+	:
+}
+
+test_js_env_001()
+{
+	_js_env test-pot
+	assertTrue "env script exists" "[ -e /tmp/pot_environment_test-pot.sh ]"
+	assertEquals "env script length" "0" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
+}
+
+test_js_env_020()
+{
+	pot-set-env -p test-pot -E VAR=value
+	_js_env test-pot
+	assertTrue "env script exists" "[ -e /tmp/pot_environment_test-pot.sh ]"
+	assertEquals "env script length" "1" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR=value"' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line2" "0" "$( grep -F -c 'export "VAR2=' /tmp/pot_environment_test-pot.sh)"
+}
+
+test_js_env_021()
+{
+	pot-set-env -p test-pot -E VAR=value -E VAR2=value2
+	_js_env test-pot
+	assertTrue "env script exists" "[ -e /tmp/pot_environment_test-pot.sh ]"
+	assertEquals "env script length" "2" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR=value"' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR2=value2"' /tmp/pot_environment_test-pot.sh)"
+}
+
+test_js_env_022()
+{
+	pot-set-env -p test-pot -E VAR="value1 value2"
+	_js_env test-pot
+	assertTrue "env script exists" "[ -e /tmp/pot_environment_test-pot.sh ]"
+	assertEquals "env script length" "1" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR=value1 value2"' /tmp/pot_environment_test-pot.sh)"
+}
+
+test_js_env_023()
+{
+	pot-set-env -p test-pot -E "VAR=value1 value2" -E VAR2=value3
+	_js_env test-pot
+	assertTrue "env script exists" "[ -e /tmp/pot_environment_test-pot.sh ]"
+	assertEquals "env script length" "2" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR=value1 value2"' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR2=value3"' /tmp/pot_environment_test-pot.sh)"
+}
+
+test_js_env_024()
+{
+	pot-set-env -p test-pot -E "EMPTYVAR="
+	_js_env test-pot
+	assertTrue "env script exists" "[ -e /tmp/pot_environment_test-pot.sh ]"
+	assertEquals "env script length" "1" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "EMPTYVAR="' /tmp/pot_environment_test-pot.sh)"
+}
+
+test_js_env_025()
+{
+	pot-set-env -p test-pot -E "VAR=12*"
+	_js_env test-pot
+	assertTrue "env script exists" "[ -e /tmp/pot_environment_test-pot.sh ]"
+	assertEquals "env script length" "1" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR=12*"' /tmp/pot_environment_test-pot.sh)"
+}
+
+test_js_env_026()
+{
+	pot-set-env -p test-pot -E "VAR=12*" -E "VAR2=?h* "
+	_js_env test-pot
+	assertTrue "env script exists" "[ -e /tmp/pot_environment_test-pot.sh ]"
+	assertEquals "env script length" "2" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR=12*"' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR2=?h* "' /tmp/pot_environment_test-pot.sh)"
+}
+
+test_js_env_040()
+{
+	pot-set-env -p test-pot -E VAR1=value1 -E "VAR2=value1 value2" -E 'VAR3=value1 value2 value3' -E VAR4=value4
+	_js_env test-pot
+	assertTrue "env script exists" "[ -e /tmp/pot_environment_test-pot.sh ]"
+	assertEquals "env script length" "4" "$( awk 'END {print NR}' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR1=value1"' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR2=value1 value2"' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR3=value1 value2 value3"' /tmp/pot_environment_test-pot.sh)"
+	assertEquals "export line" "1" "$( grep -F -c 'export "VAR4=value4"' /tmp/pot_environment_test-pot.sh)"
+}
+
+setUp()
+{
+	common_setUp
+	conf_setUp
+}
+
+tearDown()
+{
+	conf_tearDown
+}
+
+. shunit/shunit2


### PR DESCRIPTION
environment variables can now be defined and passed inside a pot.
In case of `no-rc-script` the variables will be automatically injected to the `tinirc` script that will lunch the initial command.
If `no-rc-script` is deactivated, the environment will be unaffected, but a `/tmp/environment.sh` is provided, ready to be sourced.

Currently, only `sh` syntax is supported