### PR TITLE
Add support to /etc/hosts customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- set-hosts: new command to add custom etc/hosts entries to a pot
 - set-env: new command to add environment variable to a pot
 - network-type private-bridge: add a new network layout, to provide private bridges for a group of pots
 - create-private-bridge: new subcommand to define and create a private-bridge
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - POT_EXTRA_EXTIF: add addition network interfaces support
 
 ### Changed
+- start: overwrite /etc/hosts of a pot, adding all pots on the same bridge and custom entries added via set-hosts
 - flavorable commands: extend support to set-cmd and set-env
 - pot-rdr anchor: the name of the anchor is now a truncated pot name (the last 54 characters)
 

--- a/bin/pot
+++ b/bin/pot
@@ -98,6 +98,7 @@ Commands:
 	get-rss -- Get the current resource usage
 	set-cmd -- Set the command to start the pot
 	set-env -- Set environment variabls inside a pot
+	set-hosts -- Set etc/hosts entries inside a pot
 	set-attr -- Set a pot's attribute
 	get-attr -- Get a pot's attribute
 	export-ports -- Let export tcp ports
@@ -160,7 +161,7 @@ case "${CMD}" in
 	create-base|create-fscomp|create|create-dns|\
 	create-private-bridge|\
 	copy-in|mount-in|prune|\
-	destroy|add-dep|set-rss|get-rss|set-cmd|set-env|\
+	destroy|add-dep|set-rss|get-rss|set-cmd|set-env|set-hosts|\
 	export|import|prepare|\
 	export-ports|set-attribute|get-attribute|\
 	start|stop|term|\

--- a/share/pot/set-env.sh
+++ b/share/pot/set-env.sh
@@ -20,7 +20,7 @@ _set_environment()
 	_pname="$1"
 	_tmpfile="$2"
 	_cfile=$POT_FS_ROOT/jails/$_pname/conf/pot.conf
-	sed -i '' -e "/^pot.env=.*/d" "$_cfile"
+	${SED} -i '' -e "/^pot.env=.*/d" "$_cfile"
 	cat "$_tmpfile" | sed 's/.*/pot.env=&/g' >> "$_cfile"
 }
 

--- a/share/pot/set-hosts.sh
+++ b/share/pot/set-hosts.sh
@@ -20,7 +20,7 @@ _set_hosts()
 	_pname="$1"
 	_tmpfile="$2"
 	_cfile=$POT_FS_ROOT/jails/$_pname/conf/pot.conf
-	sed -i '' -e "/^pot.hosts=.*/d" "$_cfile"
+	${SED} -i '' -e "/^pot.hosts=.*/d" "$_cfile"
 	sed 's/.*/pot.hosts=&/g' "$_tmpfile" >> "$_cfile"
 }
 

--- a/share/pot/set-hosts.sh
+++ b/share/pot/set-hosts.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+:
+
+# shellcheck disable=SC2039
+set-hosts-help() {
+	echo "pot set-hosts [-hv] -p pot -H env"
+	echo '  -h print this help'
+	echo '  -v verbose'
+	echo '  -p pot : the working pot'
+	echo '  -H hostname:IP : the hostname and the ip to be added in the /etc/hosts'
+	echo '     this option can be repeated more than once'
+}
+
+# $1 pot
+# $2 hostfile
+_set_hosts()
+{
+	# shellcheck disable=SC2039
+	local _pname _tmpfile _cfile
+	_pname="$1"
+	_tmpfile="$2"
+	_cfile=$POT_FS_ROOT/jails/$_pname/conf/pot.conf
+	sed -i '' -e "/^pot.hosts=.*/d" "$_cfile"
+	sed 's/.*/pot.hosts=&/g' "$_tmpfile" >> "$_cfile"
+}
+
+# shellcheck disable=SC2039
+pot-set-hosts()
+{
+	local _pname _hosts _tmpfile _ip _hostname
+	_hosts=
+	_pname=
+	_tmpfile="/tmp/pot-set-hosts"
+	OPTIND=1
+	while getopts "hvp:H:" _o ; do
+		case "$_o" in
+		h)
+			set-hosts-help
+			return 0
+			;;
+		v)
+			_POT_VERBOSITY=$(( _POT_VERBOSITY + 1))
+			;;
+		H)
+			if [ "$OPTARG" = "${OPTARG#*:}" ]; then
+				# the argument doesn't have an equal sign
+				_error "$OPTARG not in a valid form"
+				_error "hostname:IP is accepted"
+				set-hosts-help
+				return 1
+			fi
+			# validate IP address
+			_ip="${OPTARG#*:}"
+			_hostname="${OPTARG%%:*}"
+			if [ -z "$_ip" ] || [ -z "$_hostname" ]; then
+				_error "Submitted ip or hostname are empty"
+				set-hosts-help
+				return 1
+			fi
+			if ! potnet ipcheck -H "$_ip" ; then
+				_error "Submitted ip $_ip is not a valid one"
+				set-hosts-help
+				return 1
+			fi
+			echo "$_ip $_hostname" >> $_tmpfile
+			;;
+		p)
+			_pname="$OPTARG"
+			;;
+		?)
+			set-hosts-help
+			return 1
+		esac
+	done
+
+	if [ -z "$_pname" ]; then
+		_error "A pot name is mandatory"
+		set-hosts-help
+		return 1
+	fi
+	if ! _is_pot "$_pname" ; then
+		_error "pot $_pname is not valid"
+		set-hosts-help
+		return 1
+	fi
+	if ! _is_uid0 ; then
+		return 1
+	fi
+	_set_hosts "$_pname" "$_tmpfile"
+	rm "$_tmpfile"
+}

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -74,6 +74,28 @@ _js_resolv()
 	return 0
 }
 
+# $1 pot name
+_js_etc_hosts()
+{
+	local _pname _phosts _hostname _bridge_name _cfile
+	_pname="$1"
+	_phosts="${POT_FS_ROOT}/jails/$_pname/m/etc/hosts"
+	_hostname="$( _get_conf_var $_pname host.hostname )"
+	printf "::1 localhost %s %s\n" "$_hostname" "${_hostname%%.*}" > "$_phosts"
+	printf "127.0.0.1 localhost %s %s\n" "$_hostname" "${_hostname%%.*}" >> "$_phosts"
+	case "$( _get_conf_var "$_pname" network_type )" in
+	"public-bridge")
+		potnet etc-hosts >> "$_phosts"
+		;;
+	"private-bridge")
+		_bridge_name="$( _get_conf_var "$_pname" bridge )"
+		potnet etc-hosts -b "$_bridge_name" >> "$_phosts"
+		;;
+	esac
+	_cfile="${POT_FS_ROOT}/jails/$_pname/conf/pot.conf"
+	grep '^pot.hosts=' "$_cfile" | sed 's/^pot.hosts=//g' >> "$_phosts"
+}
+
 _js_create_epair()
 {
 	local _epair

--- a/share/zsh/site-functions/_pot
+++ b/share/zsh/site-functions/_pot
@@ -238,6 +238,13 @@ _pot() {
 						'-p[pot name]:pot name:_pot_pots' \
 						'*-E[variable list]::_normal'
 					;;
+				set-hosts)
+					_arguments \
+						'-h[Show help]' \
+						'-v[Verbose output]' \
+						'-p[pot name]:pot name:_pot_pots' \
+						'*-H[hosts entry]::_normal'
+					;;
 				set-attr|set-attribute)
 					_arguments \
 						'-h[Show help]' \
@@ -376,6 +383,7 @@ _pot_cmds() {
 	'get-rss:Get the current resource usage'
 	'set-cmd:Set the initial command of a pot'
 	'set-env:Set environment variables inside a pot'
+	'set-hosts:Set etc/hosts entries inside a pot'
 	'set-attr:Set the value of a pot attribute'
 	'set-attribute:Set the value of a pot attribute'
 	'get-attr:Get the value of a pot attribute'

--- a/tests/common-stub.sh
+++ b/tests/common-stub.sh
@@ -206,6 +206,16 @@ _get_conf_var()
 			;;
 		esac
 		;;
+	"bridge")
+		case $1 in
+		test-pot-multi-private)
+			echo "test-bridge"
+			;;
+		esac
+		;;
+	"host.hostname")
+		echo "$1.test-domain"
+		;;
 	esac
 }
 

--- a/tests/set-env2.sh
+++ b/tests/set-env2.sh
@@ -1,6 +1,15 @@
 #!/bin/sh
 
 # system utilities stubs
+SED=sed_stub
+sed_stub()
+{
+	if [ "$(uname)" = "Linux" ]; then
+		sed -i'' "$3" "$4"
+	else
+		sed "$@"
+	fi
+}
 
 # UUT
 . ../share/pot/set-env.sh

--- a/tests/set-hosts1.sh
+++ b/tests/set-hosts1.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 
 # system utilities stubs
+potnet()
+{
+	case "$4" in
+		"10.1.2.3"|"10.1.2.4"|\
+		"fe00::2"|"::1")
+		return 0 # true
+	esac
+}
 
 # UUT
 . ../share/pot/set-hosts.sh
@@ -145,7 +153,7 @@ test_pot_set_hosts_041()
 
 test_pot_set_hosts_042()
 {
-	pot-set-hosts -p test-pot -H test-pot-2:fe00::1
+	pot-set-hosts -p test-pot -H test-pot-2:fe00::2
 	assertEquals "Exit rc" "0" "$?"
 	assertEquals "Help calls" "0" "$HELP_CALLS"
 	assertEquals "Error calls" "0" "$ERROR_CALLS"
@@ -153,7 +161,7 @@ test_pot_set_hosts_042()
 	assertEquals "_set_hosts calls" "1" "$SETHOSTS_CALLS"
 	assertEquals "_set_hosts arg1" "test-pot" "$SETHOSTS_CALL1_ARG1"
 	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-hosts)"
-	assertEquals "_tmpfile" 'fe00::1 test-pot-2' "$(sed '1!d' /tmp/pot-set-hosts)"
+	assertEquals "_tmpfile" 'fe00::2 test-pot-2' "$(sed '1!d' /tmp/pot-set-hosts)"
 }
 
 test_pot_set_hosts_043()
@@ -171,7 +179,7 @@ test_pot_set_hosts_043()
 
 test_pot_set_hosts_044()
 {
-	pot-set-hosts -p test-pot -H test-pot-2:10.1.2.3 -H test-pot-3:10.1.2.4 -H test-pot-4:::1 -H test-pot-5:fe00::1
+	pot-set-hosts -p test-pot -H test-pot-2:10.1.2.3 -H test-pot-3:10.1.2.4 -H test-pot-4:::1 -H test-pot-5:fe00::2
 	assertEquals "Exit rc" "0" "$?"
 	assertEquals "Help calls" "0" "$HELP_CALLS"
 	assertEquals "Error calls" "0" "$ERROR_CALLS"
@@ -182,7 +190,7 @@ test_pot_set_hosts_044()
 	assertEquals "_tmpfile" '10.1.2.3 test-pot-2' "$(sed '1!d' /tmp/pot-set-hosts)"
 	assertEquals "_tmpfile" '10.1.2.4 test-pot-3' "$(sed '2!d' /tmp/pot-set-hosts)"
 	assertEquals "_tmpfile" '::1 test-pot-4' "$(sed '3!d' /tmp/pot-set-hosts)"
-	assertEquals "_tmpfile" 'fe00::1 test-pot-5' "$(sed '4!d' /tmp/pot-set-hosts)"
+	assertEquals "_tmpfile" 'fe00::2 test-pot-5' "$(sed '4!d' /tmp/pot-set-hosts)"
 }
 
 setUp()

--- a/tests/set-hosts1.sh
+++ b/tests/set-hosts1.sh
@@ -1,0 +1,202 @@
+#!/bin/sh
+
+# system utilities stubs
+
+# UUT
+. ../share/pot/set-hosts.sh
+
+# common stubs
+. common-stub.sh
+
+# app specific stubs
+set-hosts-help()
+{
+	__monitor HELP "$@"
+}
+
+rm()
+{
+	__monitor RM "$@"
+}
+
+_set_hosts()
+{
+	__monitor SETHOSTS "$@"
+}
+
+test_pot_set_hosts_001()
+{
+	pot-set-hosts
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "1" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
+
+	setUp
+	pot-set-hosts -bv
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
+
+	setUp
+	pot-set-hosts -b bb
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
+
+	setUp
+	pot-set-hosts -h
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
+}
+
+test_pot_set_hosts_002()
+{
+	pot-set-hosts -H test-pot-2:10.1.2.3
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "1" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
+}
+
+test_pot_set_hosts_003()
+{
+	pot-set-hosts -p test-pot -H
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
+}
+
+test_pot_set_hosts_020()
+{
+	pot-set-hosts -p test-no-pot -H test-pot-2:10.1.2.3
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "1" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
+}
+
+test_pot_set_hosts_021()
+{
+	pot-set-hosts -p test-pot -H test-pot-2
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "2" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
+}
+
+test_pot_set_hosts_022()
+{
+	pot-set-hosts -p test-pot -H test-pot-2:
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "1" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
+}
+
+test_pot_set_hosts_023()
+{
+	pot-set-hosts -p test-pot -H :10.1.2.3
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "1" "$HELP_CALLS"
+	assertEquals "Error calls" "1" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "0" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "0" "$SETHOSTS_CALLS"
+}
+
+test_pot_set_hosts_040()
+{
+	pot-set-hosts -p test-pot -H test-pot-2:10.1.2.3
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "1" "$SETHOSTS_CALLS"
+	assertEquals "_set_hosts arg1" "test-pot" "$SETHOSTS_CALL1_ARG1"
+	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-hosts)"
+	assertEquals "_tmpfile" '10.1.2.3 test-pot-2' "$(sed '1!d' /tmp/pot-set-hosts)"
+}
+
+test_pot_set_hosts_041()
+{
+	pot-set-hosts -p test-pot -H test-pot-2:10.1.2.3 -H test-pot-3:10.1.2.4
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "1" "$SETHOSTS_CALLS"
+	assertEquals "_tmpfile length" "2" "$( awk 'END {print NR}' /tmp/pot-set-hosts)"
+	assertEquals "_tmpfile" '10.1.2.3 test-pot-2' "$(sed '1!d' /tmp/pot-set-hosts)"
+	assertEquals "_tmpfile" '10.1.2.4 test-pot-3' "$(sed '2!d' /tmp/pot-set-hosts)"
+}
+
+test_pot_set_hosts_042()
+{
+	pot-set-hosts -p test-pot -H test-pot-2:fe00::1
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "1" "$SETHOSTS_CALLS"
+	assertEquals "_set_hosts arg1" "test-pot" "$SETHOSTS_CALL1_ARG1"
+	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-hosts)"
+	assertEquals "_tmpfile" 'fe00::1 test-pot-2' "$(sed '1!d' /tmp/pot-set-hosts)"
+}
+
+test_pot_set_hosts_043()
+{
+	pot-set-hosts -p test-pot -H test-pot-2:::1
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "1" "$SETHOSTS_CALLS"
+	assertEquals "_set_hosts arg1" "test-pot" "$SETHOSTS_CALL1_ARG1"
+	assertEquals "_tmpfile length" "1" "$( awk 'END {print NR}' /tmp/pot-set-hosts)"
+	assertEquals "_tmpfile" '::1 test-pot-2' "$(sed '1!d' /tmp/pot-set-hosts)"
+}
+
+test_pot_set_hosts_044()
+{
+	pot-set-hosts -p test-pot -H test-pot-2:10.1.2.3 -H test-pot-3:10.1.2.4 -H test-pot-4:::1 -H test-pot-5:fe00::1
+	assertEquals "Exit rc" "0" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "Error calls" "0" "$ERROR_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_set_hosts calls" "1" "$SETHOSTS_CALLS"
+	assertEquals "_set_hosts arg1" "test-pot" "$SETHOSTS_CALL1_ARG1"
+	assertEquals "_tmpfile length" "4" "$( awk 'END {print NR}' /tmp/pot-set-hosts)"
+	assertEquals "_tmpfile" '10.1.2.3 test-pot-2' "$(sed '1!d' /tmp/pot-set-hosts)"
+	assertEquals "_tmpfile" '10.1.2.4 test-pot-3' "$(sed '2!d' /tmp/pot-set-hosts)"
+	assertEquals "_tmpfile" '::1 test-pot-4' "$(sed '3!d' /tmp/pot-set-hosts)"
+	assertEquals "_tmpfile" 'fe00::1 test-pot-5' "$(sed '4!d' /tmp/pot-set-hosts)"
+}
+
+setUp()
+{
+	common_setUp
+	HELP_CALLS=0
+	SETHOSTS_CALLS=0
+	/bin/rm -f /tmp/pot-set-hosts
+}
+
+tearDown()
+{
+	/bin/rm -f /tmp/pot-set-hosts
+}
+
+
+. shunit/shunit2

--- a/tests/start4.sh
+++ b/tests/start4.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+# system utilities stubs
+potnet()
+{
+	if [ -z "$3" ]; then
+		# public bridge
+		echo "10.1.2.3 test-pot-2"
+		echo "10.1.2.4 test-single"
+	fi
+	if [ "$3" = "test-bridge" ]; then
+		# private-bridge
+		echo "10.1.3.3 test-pot-multi-private"
+	fi
+}
+
+# UUT
+. ../share/pot/start.sh
+
+# common stubs
+. common-stub.sh
+
+test_js_etc_hosts_000()
+{
+	_js_etc_hosts test-pot-2
+	assertTrue "/etc/hosts" "[ -r /tmp/jails/test-pot-2/m/etc ]"
+	assertEquals "/etc/hosts length" "4" "$( awk 'END {print NR}' /tmp/jails/test-pot-2/m/etc/hosts)"
+	assertEquals "127.0.0.1" "127.0.0.1 localhost test-pot-2.test-domain test-pot-2" "$( grep "^127.0.0.1" /tmp/jails/test-pot-2/m/etc/hosts)"
+	assertEquals "::1" "::1 localhost test-pot-2.test-domain test-pot-2" "$( grep "^::1" /tmp/jails/test-pot-2/m/etc/hosts)"
+	assertEquals "test-pot-2" "10.1.2.3 test-pot-2" "$( grep "^10.1.2.3 " /tmp/jails/test-pot-2/m/etc/hosts)"
+	assertEquals "test-single" "10.1.2.4 test-single" "$( grep "^10.1.2.4 " /tmp/jails/test-pot-2/m/etc/hosts)"
+}
+
+test_js_etc_hosts_001()
+{
+	_js_etc_hosts test-pot-multi-private
+	assertTrue "/etc/hosts" "[ -r /tmp/jails/test-pot-multi-private/m/etc ]"
+	assertEquals "/etc/hosts length" "3" "$( awk 'END {print NR}' /tmp/jails/test-pot-multi-private/m/etc/hosts)"
+	assertEquals "127.0.0.1" "127.0.0.1 localhost test-pot-multi-private.test-domain test-pot-multi-private" "$( grep "^127.0.0.1" /tmp/jails/test-pot-multi-private/m/etc/hosts)"
+	assertEquals "::1" "::1 localhost test-pot-multi-private.test-domain test-pot-multi-private" "$( grep "^::1" /tmp/jails/test-pot-multi-private/m/etc/hosts)"
+	assertEquals "test-pot-multi-private" "10.1.3.3 test-pot-multi-private" "$( grep "^10.1.3.3 " /tmp/jails/test-pot-multi-private/m/etc/hosts)"
+}
+
+test_js_etc_hosts_020()
+{
+	echo "pot.hosts=10.10.10.1 test-pot-custom" > /tmp/jails/test-pot-2/conf/pot.conf
+	echo "pot.hosts=10.10.10.2 test-pot-custom-2" >> /tmp/jails/test-pot-2/conf/pot.conf
+	_js_etc_hosts test-pot-2
+	assertTrue "/etc/hosts" "[ -r /tmp/jails/test-pot-2/m/etc ]"
+	assertEquals "/etc/hosts length" "6" "$( awk 'END {print NR}' /tmp/jails/test-pot-2/m/etc/hosts)"
+	assertEquals "127.0.0.1" "127.0.0.1 localhost test-pot-2.test-domain test-pot-2" "$( grep "^127.0.0.1" /tmp/jails/test-pot-2/m/etc/hosts)"
+	assertEquals "::1" "::1 localhost test-pot-2.test-domain test-pot-2" "$( grep "^::1" /tmp/jails/test-pot-2/m/etc/hosts)"
+	assertEquals "test-pot-2" "10.1.2.3 test-pot-2" "$( grep "^10.1.2.3 " /tmp/jails/test-pot-2/m/etc/hosts)"
+	assertEquals "test-single" "10.1.2.4 test-single" "$( grep "^10.1.2.4 " /tmp/jails/test-pot-2/m/etc/hosts)"
+	assertEquals "test-pot-custom" "10.10.10.1 test-pot-custom" "$( grep "^10.10.10.1 " /tmp/jails/test-pot-2/m/etc/hosts)"
+	assertEquals "test-pot-custom-2" "10.10.10.2 test-pot-custom-2" "$( grep "^10.10.10.2 " /tmp/jails/test-pot-2/m/etc/hosts)"
+}
+
+test_js_etc_hosts_021()
+{
+	echo "pot.hosts=10.10.10.1 test-pot-custom" > /tmp/jails/test-pot-multi-private/conf/pot.conf
+	echo "pot.hosts=10.10.10.2 test-pot-custom-2" >> /tmp/jails/test-pot-multi-private/conf/pot.conf
+	_js_etc_hosts test-pot-multi-private
+	assertTrue "/etc/hosts" "[ -r /tmp/jails/test-pot-multi-private/m/etc ]"
+	assertEquals "/etc/hosts length" "5" "$( awk 'END {print NR}' /tmp/jails/test-pot-multi-private/m/etc/hosts)"
+	assertEquals "127.0.0.1" "127.0.0.1 localhost test-pot-multi-private.test-domain test-pot-multi-private" "$( grep "^127.0.0.1" /tmp/jails/test-pot-multi-private/m/etc/hosts)"
+	assertEquals "::1" "::1 localhost test-pot-multi-private.test-domain test-pot-multi-private" "$( grep "^::1" /tmp/jails/test-pot-multi-private/m/etc/hosts)"
+	assertEquals "test-pot-multi-private" "10.1.3.3 test-pot-multi-private" "$( grep "^10.1.3.3 " /tmp/jails/test-pot-multi-private/m/etc/hosts)"
+	assertEquals "test-pot-custom" "10.10.10.1 test-pot-custom" "$( grep "^10.10.10.1 " /tmp/jails/test-pot-multi-private/m/etc/hosts)"
+	assertEquals "test-pot-custom-2" "10.10.10.2 test-pot-custom-2" "$( grep "^10.10.10.2 " /tmp/jails/test-pot-multi-private/m/etc/hosts)"
+}
+
+setUp()
+{
+	common_setUp
+
+	POT_FS_ROOT=/tmp
+	POT_ZFS_ROOT=zpot
+	POT_EXTIF="em2"
+
+	mkdir -p /tmp/jails/test-pot-2/m/etc
+	mkdir -p /tmp/jails/test-pot-2/conf
+	touch /tmp/jails/test-pot-2/conf/pot.conf
+	mkdir -p /tmp/jails/test-pot-multi-private/m/etc
+	mkdir -p /tmp/jails/test-pot-multi-private/conf
+	touch /tmp/jails/test-pot-multi-private/conf/pot.conf
+}
+
+tearDown()
+{
+	rm -rf /tmp/jails
+}
+. shunit/shunit2


### PR DESCRIPTION
When a `pot` starts, the `/etc/hosts` file is generated with entries from:
* all the `pot`s attached to the same bridge (public and private bridge only)
* custom entries added to the `pot` via the new command `set-hosts`