### PR TITLE
Fix a typo and refactor multiple greps into one

### DIFF
--- a/share/pot/clone.sh
+++ b/share/pot/clone.sh
@@ -172,8 +172,7 @@ _cj_conf()
 	if [ ! -d "$_pdir/conf" ]; then
 		mkdir -p "$_pdir/conf"
 	fi
-	grep -v ^host.hostname "$_pbdir/conf/pot.conf" | grep -v ^bridge \
-		grep -v ^ip | grep -v ^vnet | grep -v ^network_type | grep -v ^pot.stack > "$_pdir/conf/pot.conf"
+	grep -vE '^(host.hostname|bridge|ip|vnet|network_type|pot.stack)' $_pbdir/conf/pot.conf > "$_pdir/conf/pot.conf"
 	echo "host.hostname=\"${_pname}.$( hostname )\"" >> "$_pdir/conf/pot.conf"
 	echo "pot.stack=$_stack" >> "$_pdir/conf/pot.conf"
 	echo "network_type=$_network_type" >> "$_pdir/conf/pot.conf"


### PR DESCRIPTION
The original fix for #88 introduced a new bug in the form of a
missing pipe before a line continuation. This combined the
arguments for two grep calls into one.

Clean up the code by using a single grep -vE instead of multiple
piped grep -v.

Fixes #88.