### PR TITLE
Change mktemp call to make use of new configuration value POT_MKTEMP_SUFFIX

### DIFF
--- a/etc/pot/pot.conf.sample
+++ b/etc/pot/pot.conf.sample
@@ -10,6 +10,10 @@
 # This is the cache used to import/export pots
 # POT_CACHE=/var/cache/pot
 
+# This is the suffix added to temporary files created using mktemp,
+# X is a placeholder for a random character, see mktemp(1)
+# POT_MKTEMP_SUFFIX=.XXXXXXXX
+
 # Internal Virtual Network configuration
 
 # IPv4 Internal Virtual network

--- a/etc/pot/pot.default.conf
+++ b/etc/pot/pot.default.conf
@@ -10,6 +10,10 @@ POT_FS_ROOT=/opt/pot
 # This is the cache used to import/export pots
 POT_CACHE=/var/cache/pot
 
+# This is the suffix added to temporary files created using mktemp,
+# X is a placeholder for a random character, see mktemp(1)
+POT_MKTEMP_SUFFIX=.XXXXXXXX
+
 # Internal Virtual Network configuration
 # IPv4 Internal Virtual network
 POT_NETWORK=10.192.0.0/10

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -243,7 +243,7 @@ _js_export_ports()
 	if [ -z "$_ports" ]; then
 		return
 	fi
-	_pfrules=$(mktemp -t pot_pfrules) || exit 1
+	_pfrules=$(mktemp "/tmp/pot_pfrules_${_pname}${POT_MKTEMP_SUFFIX}") || exit 1
 	for _port in $_ports ; do
 		_pot_port="$( echo "${_port}" | cut -d':' -f 1)"
 		_host_port="$( echo "${_port}" | cut -d':' -f 2)"
@@ -334,7 +334,7 @@ _js_env()
 	local _pname _shfile _cfile
 	_pname="$1"
 	_cfile="${POT_FS_ROOT}/jails/$_pname/conf/pot.conf"
-	_shfile=$(mktemp -t pot_environment) || exit 1
+	_shfile=$(mktemp "/tmp/pot_environment_${_pname}${POT_MKTEMP_SUFFIX}") || exit 1
 	grep '^pot.env=' "$_cfile" | sed 's/^pot.env=/export /g' > "$_shfile"
 	pot-cmd info -E -p "$_pname" >> "$_shfile"
 	if [ "$(_get_conf_var "$_pname" "pot.attr.no-rc-script")" = "YES" ]; then


### PR DESCRIPTION
Add $_pname back in to support unit tests.

By default this is set to .XXXXXXX, meaning that it will set 8 random
characters. For unit tests, POT_MKTEMP_SUFFIX can be set to an empty
value or something like .sh, so that it's easy to write
unit tests against those files if necessary.

This means that $TMPDIR is ignored for the time being, which
isn't a big loss, as the rest of pot isn't looking at $TMPDIR
anyway - if pot ever is converted to using $TMPDIR in the
future, this will actually be an easy win/hard to miss.

@pizzamig This should help to balance your requirement for predictable file
names in unit tests and safety requirements of users in the field. By using /tmp
like the remainder of temporary files, it also shouldn't increase the risk of some
$TMPDIR problems that will only show up once hitting this code. Looking at the
code of mktemp (and in turn of mkstemp(...)), anything that could go wrong in there
pretty much would hit you at some point in pot anyway (as long as
POT_MKTEMP_SUFFIX isn't set to anything super broken.

I hope this helps you and that my message about the previous pull request
wasn't too aggressive - I just wanted to make sure you understand that
I think this was a real problem. Thanks for developing pot, I (still) think it's
a great approach and undervalued in FreeBSD-land.