### PR TITLE
Quote the whitespace between list elements

### DIFF
--- a/share/pot/info.sh
+++ b/share/pot/info.sh
@@ -36,8 +36,8 @@ _info_pot_env()
 				_ipvar_list="_POT_IP_$_idx"
 				_nicvar_list="_POT_NIC_$_idx"
 			else
-				_ipvar_list="$_ipvar_list _POT_IP_$_idx"
-				_nicvar_list="$_nicvar_list _POT_NIC_$_idx"
+				_ipvar_list="$_ipvar_list\\ _POT_IP_$_idx"
+				_nicvar_list="$_nicvar_list\\ _POT_NIC_$_idx"
 			fi
 			echo "export _POT_IP_$_idx=$ip"
 			echo "export _POT_NIC_$_idx=$nic"


### PR DESCRIPTION
When later executing the code generated by pot info -E -p $pot
the shell splits the lists on according to $IFS unless the
whitespace is quoted.

The alternative of wrapping the whole list in single ticks
requires a larger change.

Fixes #95.