### PR TITLE
[share] add a more general handler for jail command options

### DIFF
--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -9,7 +9,7 @@ _POT_RO_ATTRIBUTES="to-be-pruned"
 _POT_NETWORK_TYPES="inherit alias public-bridge private-bridge"
 
 # not devfs handles separately
-_POT_JAIL_RW_ATTRIBUTES='mount fdescfs linprocfs nullfs procfs tmpfs zfs children'
+_POT_JAIL_RW_ATTRIBUTES='enforce_statfs mount fdescfs linprocfs nullfs procfs tmpfs zfs children'
 
 # N: arg name jail command, T: type of data, D: deafult value
 _POT_DEFAULT_mount_N='allow.mount'
@@ -39,6 +39,10 @@ _POT_DEFAULT_zfs_D='NO'
 _POT_DEFAULT_children_N='children.max'
 _POT_DEFAULT_children_T='uint'
 _POT_DEFAULT_children_D='0'
+# 0:everything, 1:chroot+below(poudriere), 2:just chroot(normal jail)
+_POT_DEFAULT_enforce_statfs_N='enforce_statfs'
+_POT_DEFAULT_enforce_statfs_T='uint'
+_POT_DEFAULT_enforce_statfs_D='2'
 
 
 __POT_MSG_ERR=0

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -4,9 +4,42 @@
 : "${ECHO:=echo}"
 : "${SED:=sed}"
 
-_POT_RW_ATTRIBUTES="start-at-boot early-start-at-boot persistent no-rc-script procfs fdescfs prunable localhost-tunnel"
+_POT_RW_ATTRIBUTES="start-at-boot early-start-at-boot persistent no-rc-script prunable localhost-tunnel"
 _POT_RO_ATTRIBUTES="to-be-pruned"
 _POT_NETWORK_TYPES="inherit alias public-bridge private-bridge"
+
+# not devfs handles separately
+_POT_JAIL_RW_ATTRIBUTES='mount fdescfs linprocfs nullfs procfs tmpfs zfs children'
+
+# N: arg name jail command, T: type of data, D: deafult value
+_POT_DEFAULT_mount_N='allow.mount'
+_POT_DEFAULT_mount_T='bool'
+_POT_DEFAULT_mount_D='NO'
+#_POT_DEFAULT_devfs_N='allow.mount.devfs'
+#_POT_DEFAULT_devfs_T='bool'
+#_POT_DEFAULT_devfs_D='YES'
+_POT_DEFAULT_fdescfs_N='allow.mount.fdescfs'
+_POT_DEFAULT_fdescfs_T='bool'
+_POT_DEFAULT_fdescfs_D='NO'
+_POT_DEFAULT_linprocfs_N='allow.mount.linprocfs'
+_POT_DEFAULT_linprocfs_T='bool'
+_POT_DEFAULT_linprocfs_D='NO'
+_POT_DEFAULT_nullcfs_N='allow.mount.nullfs'
+_POT_DEFAULT_nullcfs_T='bool'
+_POT_DEFAULT_nullcfs_D='NO'
+_POT_DEFAULT_procfs_N='allow.mount.procfs'
+_POT_DEFAULT_procfs_T='bool'
+_POT_DEFAULT_procfs_D='NO'
+_POT_DEFAULT_tmpfs_N='allow.mount.tmpfs'
+_POT_DEFAULT_tmpfs_T='bool'
+_POT_DEFAULT_tmpfs_D='NO'
+_POT_DEFAULT_zfs_N='allow.mount.zfs'
+_POT_DEFAULT_zfs_T='bool'
+_POT_DEFAULT_zfs_D='NO'
+_POT_DEFAULT_children_N='children.max'
+_POT_DEFAULT_children_T='uint'
+_POT_DEFAULT_children_D='0'
+
 
 __POT_MSG_ERR=0
 __POT_MSG_INFO=1

--- a/share/pot/update-config.sh
+++ b/share/pot/update-config.sh
@@ -26,7 +26,7 @@ _get_conf_static_ports()
 _update_one_pot()
 {
 	# shellcheck disable=SC2039
-	local _pname _conf
+	local _pname _conf _attr _value
 	_pname="$1"
 	if ! _is_pot "$_pname" ; then
 		_error "Invalid pot name"
@@ -61,14 +61,16 @@ _update_one_pot()
 		_debug "pot.attr.early.start-at-boot=NO"
 		echo "pot.attr.early.start-at-boot=NO" >> "$_conf"
 	fi
-	if [ -z "$(_get_conf_var "$_pname" "pot.attr.procfs")" ]; then
-		_debug "pot.attr.procfs=NO"
-		echo "pot.attr.procfs=NO" >> "$_conf"
-	fi
-	if [ -z "$(_get_conf_var "$_pname" "pot.attr.fdescfs")" ]; then
-		_debug "pot.attr.fdescfs=NO"
-		echo "pot.attr.fdescfs=NO" >> "$_conf"
-	fi
+
+	for _attr in ${_POT_JAIL_RW_ATTRIBUTES}
+	do
+		if [ -z "$(_get_conf_var "$_pname" "pot.attr.${_attr}")" ]; then
+			eval _value=\"\${_POT_DEFAULT_${_attr}_D}\"
+			_debug "pot.attr.${_attr}=${_value}"
+			echo "pot.attr.${_attr}=${_value}" >> "$_conf"
+		fi
+	done
+
 	if [ -z "$(_get_conf_var "$_pname" "pot.attr.prunable")" ]; then
 		_debug "pot.attr.prunable=NO"
 		echo "pot.attr.prunable=NO" >> "$_conf"
@@ -180,7 +182,7 @@ pot-update-config()
 		if ! _update_all_pots ; then
 			${EXIT} 1
 		fi
-	else 
+	else
 		_error "A pot name or -a are mandatory"
 		update-config-help
 		${EXIT} 1


### PR DESCRIPTION
this allows setting of more attributes including numeric ones
like children.max.

the pot.con uses single words and a table is used to translate to
the longer dotted names used by the jail command

defaults are provided for all items

since mouny.devfs ialways true and is handled separately it is
excluded from the list

Signed-off-by: Christopher Hall <hsw@ms2.hinet.net>