### PR TITLE
Fix unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - clone: fix a typo refactoring the grep that remove network parameters (#90)
 - mount-in: fix mountpoint validation when pot is stopped and -v is passed (#93)
 - clone: hooks have been ignored by clone (#94)
+- info: fix withespace quoting with -E flag (#95)
+- prepare: fix -i command to allow multiple IP addresses (#97)
 
 ## [0.11.1] 2020-04-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - clone: hooks have been ignored by clone (#94)
 - info: fix withespace quoting with -E flag (#95)
 - prepare: fix -i command to allow multiple IP addresses (#97)
+- ifconfig: force IFCONFIG_FORMAT to avoid conflicting user setting (#99)
 
 ## [0.11.1] 2020-04-19
 ### Fixed

--- a/bin/pot
+++ b/bin/pot
@@ -28,6 +28,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# Force ifconfig into expected format
+export IFCONFIG_FORMAT=addr:default
+
 # Environment initialization and initial checks
 
 _POT_VERSION=0.11.2

--- a/tests/info2.sh
+++ b/tests/info2.sh
@@ -78,8 +78,8 @@ test_info_pot_env_001()
 test_info_pot_env_020()
 {
 	assertEquals "alias has wrong IP"        "export _POT_IP=192.168.0.1" "$( _info_pot_env test-pot-alias | grep _POT_IP= )"
-	assertEquals "alias has wrong IP LIST"   "$( _info_pot_env test-pot-alias | grep _POT_IP_LIST= )" "export _POT_IP_LIST=_POT_IP_0 _POT_IP_1"
-	assertEquals "alias has wrong NIC LIST"  "$( _info_pot_env test-pot-alias | grep _POT_NIC_LIST= )" "export _POT_NIC_LIST=_POT_NIC_0 _POT_NIC_1"
+	assertEquals "alias has wrong IP LIST"   "$( _info_pot_env test-pot-alias | grep _POT_IP_LIST= )" "export _POT_IP_LIST=_POT_IP_0\ _POT_IP_1"
+	assertEquals "alias has wrong NIC LIST"  "$( _info_pot_env test-pot-alias | grep _POT_NIC_LIST= )" "export _POT_NIC_LIST=_POT_NIC_0\ _POT_NIC_1"
 	assertEquals "alias has wrong IP 0"      "$( _info_pot_env test-pot-alias | grep _POT_IP_0= )" "export _POT_IP_0=192.168.0.1"
 	assertEquals "alias has wrong IP 1"      "$( _info_pot_env test-pot-alias | grep _POT_IP_1= )" "export _POT_IP_1=fe80::0"
 	assertEquals "alias has wrong NIC 0"     "$( _info_pot_env test-pot-alias | grep _POT_NIC_0= )" "export _POT_NIC_0=em0"

--- a/tests/start2.sh
+++ b/tests/start2.sh
@@ -9,7 +9,7 @@ pfctl()
 # UUT
 . ../share/pot/start.sh
 
-. ../share/pot/start.sh
+POT_MKTEMP_SUFFIX=XX
 
 # common stubs
 . common-stub.sh

--- a/tests/start2.sh
+++ b/tests/start2.sh
@@ -9,7 +9,7 @@ pfctl()
 # UUT
 . ../share/pot/start.sh
 
-POT_MKTEMP_SUFFIX=XX
+POT_MKTEMP_SUFFIX=XXX
 
 # common stubs
 . common-stub.sh

--- a/tests/start3.sh
+++ b/tests/start3.sh
@@ -17,6 +17,8 @@ sed_stub()
 	fi
 }
 
+POT_MKTEMP_SUFFIX=XXX
+
 # UUT
 . ../share/pot/start.sh
 


### PR DESCRIPTION
Currently mktemp invocation on Linux is not working.
This patch should fix it, cleaning the tests execution