### PR TITLE
Limit length of hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- pot.conf: add parameter to control max hostname length inside the pot (#118)
+
+### Changed
+- hostname: max default length for hostname set to 64 (#118)
+- create: adopt the new hostname length parameter (#118)
+- clone: adopt the new hostname length parameter (#118)
+
 
 ## [0.11.6] 2020-12-14
 ### Fixed
-stop: remove resolv.conf only if dns is not off (#117)
+- stop: remove resolv.conf only if dns is not off (#117)
 
 ## [0.11.5] 2020-11-21
 ### Added
@@ -297,7 +305,7 @@ stop: remove resolv.conf only if dns is not off (#117)
 ### Fixed
 - is_pot: improve support to single pots, that don't have fscomp.conf file
 - create-base: fix regression introduced on 0.5.9 (RC support and create -F removal)
- 
+
 ## [0.5.9] 2018-12-16
 ### Added
 - Add support to RC FreeBSD version
@@ -328,7 +336,7 @@ stop: remove resolv.conf only if dns is not off (#117)
 - add-fscomp : if the pot is running, mount the new fscomp right away
 
 ### Fixed
-- clone : fix a misleading/false positive error message 
+- clone : fix a misleading/false positive error message
 - clone : fix syslogd configuration in the cloned pot
 - destroy : fix if pot is a single dataset one
 - start : fix hostname warning

--- a/etc/pot/pot.conf.sample
+++ b/etc/pot/pot.conf.sample
@@ -14,6 +14,9 @@
 # X is a placeholder for a random character, see mktemp(1)
 # POT_MKTEMP_SUFFIX=.XXXXXXXX
 
+# Define the max length of the hostname inside the pot
+# POT_HOSTNAME_MAX_LENGTH=64
+
 # Internal Virtual Network configuration
 
 # IPv4 Internal Virtual network

--- a/etc/pot/pot.default.conf
+++ b/etc/pot/pot.default.conf
@@ -14,6 +14,9 @@ POT_CACHE=/var/cache/pot
 # X is a placeholder for a random character, see mktemp(1)
 POT_MKTEMP_SUFFIX=.XXXXXXXX
 
+# Define the max length of the hostname inside the pot
+POT_HOSTNAME_MAX_LENGTH=64
+
 # Internal Virtual Network configuration
 # IPv4 Internal Virtual network
 POT_NETWORK=10.192.0.0/10

--- a/share/pot/clone.sh
+++ b/share/pot/clone.sh
@@ -173,7 +173,7 @@ _cj_conf()
 		mkdir -p "$_pdir/conf"
 	fi
 	grep -vE '^(host.hostname|bridge|ip|vnet|network_type|pot.stack)' $_pbdir/conf/pot.conf > "$_pdir/conf/pot.conf"
-	echo "host.hostname=\"${_pname}.$( hostname )\"" >> "$_pdir/conf/pot.conf"
+	echo "host.hostname=\"$( _get_usable_hostname "${_pname}" )\"" >> "$_pdir/conf/pot.conf"
 	echo "pot.stack=$_stack" >> "$_pdir/conf/pot.conf"
 	echo "network_type=$_network_type" >> "$_pdir/conf/pot.conf"
 	case "$_network_type" in

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -381,6 +381,25 @@ _is_zfs_pot_snap()
 	fi
 }
 
+# $1 pot name
+# tested (common.sh 7)
+_get_usable_hostname() {
+	# shellcheck disable=SC2039
+	local _pname _hname _phname
+	_pname="$1"
+	_hname="$(hostname)"
+	if [ ${#_pname} -gt "${_POT_HOSTNAME_MAX_LENGTH:-64}" ]; then
+		echo "$_pname" | awk '{ truncated = substr($1, 1, 64); printf("%s", truncated); }'
+	else
+		_phname="${_pname}.$_hname"
+		if [ ${#_phname} -gt "${_POT_HOSTNAME_MAX_LENGTH:-64}" ]; then
+			echo "$_pname"
+		else
+			echo "$_phname"
+		fi
+	fi
+}
+
 # $1 bridge name
 # $2 var name
 _get_bridge_var()

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -388,11 +388,11 @@ _get_usable_hostname() {
 	local _pname _hname _phname
 	_pname="$1"
 	_hname="$(hostname)"
-	if [ ${#_pname} -gt "${_POT_HOSTNAME_MAX_LENGTH:-64}" ]; then
-		echo "$_pname" | awk '{ truncated = substr($1, 1, 64); printf("%s", truncated); }'
+	if [ ${#_pname} -gt "${POT_HOSTNAME_MAX_LENGTH:-64}" ]; then
+		echo "$_pname" | awk -v len="${POT_HOSTNAME_MAX_LENGTH:-64}" '{ truncated = substr($1, 1, len); printf("%s", truncated); }'
 	else
 		_phname="${_pname}.$_hname"
-		if [ ${#_phname} -gt "${_POT_HOSTNAME_MAX_LENGTH:-64}" ]; then
+		if [ ${#_phname} -gt "${POT_HOSTNAME_MAX_LENGTH:-64}" ]; then
 			echo "$_pname"
 		else
 			echo "$_phname"

--- a/share/pot/create.sh
+++ b/share/pot/create.sh
@@ -292,7 +292,7 @@ _cj_conf()
 		echo "pot.potbase=${_potbase}"
 		echo "pot.dns=${_dns}"
 		echo "pot.cmd=sh /etc/rc"
-		echo "host.hostname=\"${_pname}.$( hostname )\""
+		echo "host.hostname=\"$( _get_usable_hostname "${_pname}" )\""
 		if echo "$_baseos" | grep -q "RC" ; then
 			echo "osrelease=\"${_baseos}\""
 		elif echo "$_baseos" | grep -q "RELEASE" ; then

--- a/tests/common7.sh
+++ b/tests/common7.sh
@@ -2,14 +2,6 @@
 
 # system utilities stubs
 
-# UUT
-. ../share/pot/common.sh
-
-# common stubs
-. ./monitor.sh
-
-# app specific stubs
-
 find()
 {
 	cat << MANIFEST-EOF
@@ -33,6 +25,20 @@ sysctl()
 {
 	echo "amd64"
 }
+
+hostname()
+{
+	echo "test-host"
+}
+
+# UUT
+. ../share/pot/common.sh
+
+# common stubs
+. ./monitor.sh
+
+# app specific stubs
+
 
 test_map_archs_001()
 {
@@ -74,4 +80,22 @@ test_is_valid_release_002()
 	assertEquals "1" "$?"
 }
 
+test_get_usable_hostname_001()
+{
+	result="$( _get_usable_hostname pot-short-name )"
+	assertEquals "pot-short-name.test-host" "$result"
+
+}
+
+test_get_usable_hostname_002()
+{
+	result="$( _get_usable_hostname pot-long-name-01234567890123456789012345678901234567890123456789 )"
+	assertEquals "pot-long-name-01234567890123456789012345678901234567890123456789" "$result"
+}
+
+test_get_usable_hostname_003()
+{
+	result="$( _get_usable_hostname pot-long-name-012345678901234567890123456789012345678901234567890123456789 )"
+	assertEquals "pot-long-name-01234567890123456789012345678901234567890123456789" "$result"
+}
 . shunit/shunit2

--- a/tests/common7.sh
+++ b/tests/common7.sh
@@ -98,4 +98,11 @@ test_get_usable_hostname_003()
 	result="$( _get_usable_hostname pot-long-name-012345678901234567890123456789012345678901234567890123456789 )"
 	assertEquals "pot-long-name-01234567890123456789012345678901234567890123456789" "$result"
 }
+
+test_get_usable_hostname_004()
+{
+	export POT_HOSTNAME_MAX_LENGTH=62
+	result="$( _get_usable_hostname pot-long-name-012345678901234567890123456789012345678901234567890123456789 )"
+	assertEquals "pot-long-name-012345678901234567890123456789012345678901234567" "$result"
+}
 . shunit/shunit2


### PR DESCRIPTION
Implement a way to limit the length of the `pot` hostname.
By default, the limit is 64 character.
In `pot.conf` a new variable can be used to customize this value.

issue #118 