### PR TITLE
Extif noalias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - hostname: max default length for hostname set to 64 (#118)
 - create: adopt the new hostname length parameter (#118)
 - clone: adopt the new hostname length parameter (#118)
+- ext-if: do not include interface aliases in the bridges network if EXTIF has them
 
 
 ## [0.11.6] 2020-12-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - hostname: max default length for hostname set to 64 (#118)
 - create: adopt the new hostname length parameter (#118)
 - clone: adopt the new hostname length parameter (#118)
-- ext-if: do not include interface aliases in the bridges network if EXTIF has them
-
+- ext-if: do not include interface aliases in the bridges network if EXTIF has them (#120)
 
 ## [0.11.6] 2020-12-14
 ### Fixed

--- a/share/pot/vnet-start.sh
+++ b/share/pot/vnet-start.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-
+:
+# shellcheck disable=SC2039
 vnet-start-help()
 {
 	echo 'pot vnet-start [-h][-v]'
@@ -57,6 +58,7 @@ _private_bridge_start()
 
 _ipv4_start()
 {
+	# shellcheck disable=SC2039
 	local _bridge_name pf_file _nat_rules
 	_bridge_name="$1"
 	# activate ip forwarding
@@ -151,6 +153,7 @@ _ipv6_start()
 	_ipv6_bridge_start
 }
 
+# shellcheck disable=SC2039
 pot-vnet-start()
 {
 	# shellcheck disable=SC2039
@@ -200,4 +203,3 @@ pot-vnet-start()
 			;;
 	esac
 }
-

--- a/share/pot/vnet-start.sh
+++ b/share/pot/vnet-start.sh
@@ -91,22 +91,23 @@ _ipv4_start()
 	(
 		echo "ext_if = \"${POT_EXTIF}\""
 		echo "localnet = \"${POT_NETWORK}\""
-		echo "nat on \$ext_if from \$localnet to any -> (\$ext_if)"
+		echo "nat on \$ext_if from \$localnet to any -> (\$ext_if:0)"
 	) > $_nat_rules
 
 	# EXTRA_EXTIF NAT rules
 	if [ -n "$POT_EXTRA_EXTIF" ]; then
 		for extra_netif in $POT_EXTRA_EXTIF ; do
 			eval extra_net="\$POT_NETWORK_$extra_netif"
+			# shellcheck disable=SC2154
 			if [ -n "$extra_net" ]; then
-				echo "nat on $extra_netif from \$localnet to $extra_net -> ($extra_netif)" >> $_nat_rules
+				echo "nat on $extra_netif from \$localnet to $extra_net -> ($extra_netif:0)" >> $_nat_rules
 			fi
 		done
 	fi
 	# VPN NAT rules
 	if [ -n "$POT_VPN_EXTIF" ] && [ -n "$POT_VPN_NETWORKS" ]; then
 		for net in $POT_VPN_NETWORKS ; do
-			echo "nat on $POT_VPN_EXTIF from \$localnet to $net -> ($POT_VPN_EXTIF)" >> $_nat_rules
+			echo "nat on $POT_VPN_EXTIF from \$localnet to $net -> ($POT_VPN_EXTIF:0)" >> $_nat_rules
 		done
 	fi
 


### PR DESCRIPTION
In the firewall rules, `pf` can be confused if the outbound interface has an alias.
This patch will remove the alias for the NAT to mitigate the issue #120 