### PR TITLE
Add flavour support to clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - export-ports: add UDP support, as -e udp:53:53 (#115)
 - create: dns custom allows to statically provide a resolv.conf
 - POT_EXTIF_ADDR: new parameter to force which IP of EXTIF should be used for NAT and RDR
+- clone: add support for applying flavors to cloned pots
 
 ### Changed
 - hostname: max default length for hostname set to 64 (#118)

--- a/bin/pot
+++ b/bin/pot
@@ -47,21 +47,28 @@ else
 fi
 
 if [ ! -d "${_POT_INCLUDE}" ]; then
-	echo "Fatal error! Not able to find the subroutines dir on ${_POT_INCLUDE}!"
+	echo "Fatal error! Not able to find the subroutines directory as ${_POT_INCLUDE}!"
 	exit 1
 fi
 
 # loading subroutines
 
 if [ ! -r "${_POT_INCLUDE}/common.sh" ]; then
-	echo "Fatal error! Not able to find common subroutines on ${_POT_INCLUDE}!"
+	echo "Fatal error! Not able to find common subroutines in ${_POT_INCLUDE}!"
 	exit 1
 fi
 # shellcheck disable=SC1090
 . "${_POT_INCLUDE}/common.sh"
 
+if [ ! -r "${_POT_INCLUDE}/common-flv.sh" ]; then
+	echo "Fatal error! Not able to find flavor subroutines in ${_POT_INCLUDE}!"
+	exit 1
+fi
+# shellcheck disable=SC1090
+. "${_POT_INCLUDE}/common-flv.sh"
+
 if [ ! -r "${_POT_INCLUDE}/network.sh" ]; then
-	echo "Fatal error! Not able to find network subroutines on ${_POT_INCLUDE}!"
+	echo "Fatal error! Not able to find network subroutines in ${_POT_INCLUDE}!"
 	exit 1
 fi
 # shellcheck disable=SC1090

--- a/share/pot/clone.sh
+++ b/share/pot/clone.sh
@@ -272,7 +272,7 @@ pot-clone()
 				_autosnap="YES"
 				;;
 			f)
-				if ! _is_flavouridr ; then
+				if ! _is_flavourdir ; then
 					_error "The flavour directory is missing"
 					${EXIT} 1
 				fi

--- a/share/pot/common-flv.sh
+++ b/share/pot/common-flv.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+# Special version of set-cmd usable only for flavours
+# $1 : pot name
+# $2 : the set-cmd line in the file
+_flv_set_cmd()
+{
+	# shellcheck disable=SC2039
+	local _pname _line _cmd
+	_pname="$1"
+	_line="$2"
+	_cmd="${_line#set-cmd -c }"
+	if [ "$_line" = "$_cmd" ]; then
+		_error "In flavour only 'set-cmd -c ' is supported"
+		return 1
+	fi
+	_set_command "$_pname" "$_cmd"
+}
+
+_exec_flv()
+{
+	# shellcheck disable=SC2039
+	local _pname _flv _pdir
+	_pname=$1
+	_flv=$2
+	_pdir=${POT_FS_ROOT}/jails/$_pname
+	_debug "Flavour: $_flv"
+	if [ -r "${_POT_FLAVOUR_DIR}/${_flv}" ]; then
+		_debug "Executing $_flv pot commands on $_pname"
+		while read -r line ; do
+			# shellcheck disable=SC2086
+			if _is_cmd_flavorable $line ; then
+				if [ "$line" != "${line#set-cmd}" ]; then
+					# workaround for set-cmd / damn quoting and shell scripts
+					if ! _flv_set_cmd "$_pname" "$line" ; then
+						return 1
+					fi
+				else
+					# shellcheck disable=SC2086
+					pot-cmd $line -p "$_pname"
+				fi
+			else
+				_error "Flavor $_flv: line $line not valid - ignoring"
+			fi
+		done < "${_POT_FLAVOUR_DIR}/${_flv}"
+	fi
+	if [ -x "${_POT_FLAVOUR_DIR}/${_flv}.sh" ]; then
+		_debug "Starting $_pname pot for the initial bootstrap"
+		pot-cmd start "$_pname"
+		cp -v "${_POT_FLAVOUR_DIR}/${_flv}.sh" "$_pdir/m/tmp"
+		_debug "Executing $_flv script on $_pname"
+		if ! jexec "$_pname" "/tmp/${_flv}.sh" "$_pname" ; then
+			_error "create: flavour $_flv failed (script)"
+			return 1
+		fi
+		pot-cmd stop "$_pname"
+	else
+		_debug "No shell script available for the flavour $_flv"
+	fi
+
+}

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -100,18 +100,14 @@ _set_pipefail()
 	# shellcheck disable=SC2039
 	local _major _version
 	_major="$(sysctl -n kern.osrelease | cut -f 1 -d '.')"
-	_version="$(sysctl -n kern.osrelease | cut -f 1 -d '-')"
 	if [ "$_major" -ge "13" ]; then
 		# shellcheck disable=SC2039
 		set -o pipefail
 		return
 	fi
+	_version="$(sysctl -n kern.osrelease | cut -f 1 -d '-')"
 	case "$_version" in
-		"12.1")
-			# shellcheck disable=SC2039
-			set -o pipefail
-			;;
-		"12.2")
+		"12.1"|"12.2")
 			# shellcheck disable=SC2039
 			set -o pipefail
 			;;

--- a/share/pot/create.sh
+++ b/share/pot/create.sh
@@ -560,7 +560,7 @@ pot-create()
 			;;
 		f)
 			if ! _is_flavourdir ; then
-				_error "The flavour dir is missing"
+				_error "The flavour directory is missing"
 				${EXIT} 1
 			fi
 			if _is_flavour "$OPTARG" ; then
@@ -570,7 +570,7 @@ pot-create()
 					_flv="$_flv $OPTARG"
 				fi
 			else
-				_error "The flavour $OPTARG not found"
+				_error "Flavour $OPTARG not found"
 				_debug "Looking in the flavour dir ${_POT_FLAVOUR_DIR}"
 				${EXIT} 1
 			fi

--- a/share/pot/create.sh
+++ b/share/pot/create.sh
@@ -413,66 +413,6 @@ _cj_internal_conf()
 #	fi
 }
 
-# Special version of set-cmd usable only for flavours
-# $1 : pot name
-# $2 : the set-cmd line in the file
-_cj_flv_set_cmd()
-{
-	# shellcheck disable=SC2039
-	local _pname _line _cmd
-	_pname="$1"
-	_line="$2"
-	_cmd="${_line#set-cmd -c }"
-	if [ "$_line" = "$_cmd" ]; then
-		_error "In flavour only 'set-cmd -c ' is supported"
-		return
-	fi
-	_set_command "$_pname" "$_cmd"
-}
-
-# $1 pot name
-# $2 flavour name
-_cj_flv()
-{
-	# shellcheck disable=SC2039
-	local _pname _flv _pdir
-	_pname=$1
-	_flv=$2
-	_pdir=${POT_FS_ROOT}/jails/$_pname
-	_debug "Flavour: $_flv"
-	if [ -r "${_POT_FLAVOUR_DIR}/${_flv}" ]; then
-		_debug "Executing $_flv pot commands on $_pname"
-		while read -r line ; do
-			# shellcheck disable=SC2086
-			if _is_cmd_flavorable $line ; then
-				if [ "$line" != "${line#set-cmd}" ]; then
-					# workaround for set-cmd / damn quoting and shell script
-					_cj_flv_set_cmd "$_pname" "$line"
-				else
-					# shellcheck disable=SC2086
-					pot-cmd $line -p "$_pname"
-				fi
-			else
-				_error "Flavor $_flv: line $line not valid - ignoring"
-			fi
-		done < "${_POT_FLAVOUR_DIR}/${_flv}"
-	fi
-	if [ -x "${_POT_FLAVOUR_DIR}/${_flv}.sh" ]; then
-		_debug "Starting $_pname pot for the initial bootstrap"
-		pot-cmd start "$_pname"
-		cp -v "${_POT_FLAVOUR_DIR}/${_flv}.sh" "$_pdir/m/tmp"
-		_debug "Executing $_flv script on $_pname"
-		if ! jexec "$_pname" "/tmp/${_flv}.sh" "$_pname" ; then
-			_error "create: flavour $_flv failed (script)"
-			_cj_undo_create
-			return 1
-		fi
-		pot-cmd stop "$_pname"
-	else
-		_debug "No shell script available for the flavour $_flv"
-	fi
-}
-
 # $1 pot name
 # $2 freebsd version
 _cj_single_install()
@@ -837,7 +777,10 @@ pot-create()
 	fi
 	if [ -n "$_flv" ]; then
 		for _f in $_flv ; do
-			_cj_flv "$_pname" "$_f"
+			if ! _exec_flv "$_pname" "$_f" ; then
+				_cj_undo_create
+				${EXIT} 1
+			fi
 		done
 	fi
 }

--- a/share/zsh/site-functions/_pot
+++ b/share/zsh/site-functions/_pot
@@ -156,6 +156,7 @@ _pot() {
 						'-v[Verbose output]' \
 						'-p[pot name]::_normal' \
 						'-P[pot reference]:pot reference name:_pot_pots' \
+						'*-f[flavour name]:flavour name:_pot_flavours'
 						'-N[network type]:network type:_pot_network_type' \
 						'-i[network config]::_normal' \
 						'-B[bridge name]:bridge name:_pot_bridges' \

--- a/tests/clone2.sh
+++ b/tests/clone2.sh
@@ -67,6 +67,11 @@ _zfs_last_snap()
 	esac
 }
 
+_cj_undo_clone()
+{
+	__monitor UNDO_CLONE "$@"
+}
+
 test_cj_zfs_001()
 {
 	_cj_zfs new-pot test-pot
@@ -165,11 +170,10 @@ test_cj_zfs_020()
 {
 	_cj_zfs new-pot test-pot-nosnap NO
 	assertNotEquals "return code" "0" "$?"
-	assertEquals "zfs calls" "2" "$ZFS_CALLS"
+	assertEquals "zfs calls" "1" "$ZFS_CALLS"
 	assertEquals "zfs arg1" "create" "$ZFS_CALL1_ARG1"
 	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL1_ARG2"
-	assertEquals "zfs arg1" "destroy" "$ZFS_CALL2_ARG1"
-	assertEquals "zfs arg2" "${POT_ZFS_ROOT}/jails/new-pot" "$ZFS_CALL2_ARG3"
+	assertEquals "undo_clone calls" "1" "$UNDO_CLONE_CALLS"
 }
 
 test_cj_zfs_040()
@@ -211,6 +215,7 @@ setUp()
 	DATE_CALLS=0
 	ZFSDATASETVALID_CALLS=0
 	ZFSLASTSNAP_CALLS=0
+	UNDO_CLONE_CALLS=0
 }
 
 tearDown()

--- a/tests/create1.sh
+++ b/tests/create1.sh
@@ -73,9 +73,9 @@ _cj_single_install()
 	__monitor CJSINGLE "$@"
 }
 
-_cj_flv()
+_exec_flv()
 {
-	__monitor CJFLV "$@"
+	__monitor EXEC_FLV "$@"
 }
 
 create-help()
@@ -94,7 +94,7 @@ test_pot_create_001()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 
 	setUp
 	pot-create -vL
@@ -106,7 +106,7 @@ test_pot_create_001()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 
 	setUp
 	pot-create -L bb
@@ -118,7 +118,7 @@ test_pot_create_001()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 
 	setUp
 	pot-create -h
@@ -130,7 +130,7 @@ test_pot_create_001()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 
 	setUp
 	pot-create -S
@@ -142,7 +142,7 @@ test_pot_create_001()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_002()
@@ -156,7 +156,7 @@ test_pot_create_002()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_003()
@@ -170,7 +170,7 @@ test_pot_create_003()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 
 	setUp
 	pot-create -p new-pot -b 11.1 -P test-pot -l 0
@@ -182,7 +182,7 @@ test_pot_create_003()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_004()
@@ -196,7 +196,7 @@ test_pot_create_004()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 
 	setUp
 	pot-create -p new-pot -P test-pot2 -l 1
@@ -208,7 +208,7 @@ test_pot_create_004()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 
 	setUp
 	pot-create -p new-pot -b 11.1 -l 2
@@ -220,7 +220,7 @@ test_pot_create_004()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_005()
@@ -233,7 +233,7 @@ test_pot_create_005()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 
 	setUp
 	pot-create -p new-pot -b 12.1 -N alias -I removed-option
@@ -244,7 +244,7 @@ test_pot_create_005()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_006()
@@ -257,7 +257,7 @@ test_pot_create_006()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_020()
@@ -286,7 +286,7 @@ test_pot_create_020()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_021()
@@ -315,7 +315,7 @@ test_pot_create_021()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_022()
@@ -329,7 +329,7 @@ test_pot_create_022()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_023()
@@ -343,7 +343,7 @@ test_pot_create_023()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_024()
@@ -357,7 +357,7 @@ test_pot_create_024()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_025()
@@ -386,7 +386,7 @@ test_pot_create_025()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_026()
@@ -415,8 +415,8 @@ test_pot_create_026()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "1" "$CJFLV_CALLS"
-	assertEquals "_cj_flv arg2" "flap" "$CJFLV_CALL1_ARG2"
+	assertEquals "_exec_flv calls" "1" "$EXEC_FLV_CALLS"
+	assertEquals "_exec_flv arg2" "flap" "$EXEC_FLV_CALL1_ARG2"
 }
 
 test_pot_create_027()
@@ -445,8 +445,8 @@ test_pot_create_027()
 	assertEquals "_cj_conf_arg10" "ipv6" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "1" "$CJFLV_CALLS"
-	assertEquals "_cj_flv arg2" "flap" "$CJFLV_CALL1_ARG2"
+	assertEquals "_exec_flv calls" "1" "$EXEC_FLV_CALLS"
+	assertEquals "_exec_flv arg2" "flap" "$EXEC_FLV_CALL1_ARG2"
 }
 
 test_pot_create_028()
@@ -475,9 +475,9 @@ test_pot_create_028()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "2" "$CJFLV_CALLS"
-	assertEquals "_cj_flv arg2" "flap" "$CJFLV_CALL1_ARG2"
-	assertEquals "_cj_flv arg2" "flap2" "$CJFLV_CALL2_ARG2"
+	assertEquals "_exec_flv calls" "2" "$EXEC_FLV_CALLS"
+	assertEquals "_exec_flv arg2" "flap" "$EXEC_FLV_CALL1_ARG2"
+	assertEquals "_exec_flv arg2" "flap2" "$EXEC_FLV_CALL2_ARG2"
 }
 
 test_pot_create_030()
@@ -491,7 +491,7 @@ test_pot_create_030()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 test_pot_create_040()
 {
@@ -518,7 +518,7 @@ test_pot_create_040()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_041()
@@ -546,7 +546,7 @@ test_pot_create_041()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_042()
@@ -560,7 +560,7 @@ test_pot_create_042()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_060()
@@ -589,7 +589,7 @@ test_pot_create_060()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 	assertEquals "_potnet calls" "0" "$POTNET_CALLS"
 }
 
@@ -603,7 +603,7 @@ test_pot_create_061()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_062()
@@ -631,7 +631,7 @@ test_pot_create_062()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_063()
@@ -660,7 +660,7 @@ test_pot_create_063()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_064()
@@ -688,7 +688,7 @@ test_pot_create_064()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_065()
@@ -700,7 +700,7 @@ test_pot_create_065()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 	# an empty error message is printed because _error is re-implemented in the stub
 }
 
@@ -715,7 +715,7 @@ test_pot_create_080()
 	assertEquals "_cj_conf calls" "0" "$CJCONF_CALLS"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_081()
@@ -744,7 +744,7 @@ test_pot_create_081()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_082()
@@ -773,7 +773,7 @@ test_pot_create_082()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_083()
@@ -802,7 +802,7 @@ test_pot_create_083()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_084()
@@ -831,7 +831,7 @@ test_pot_create_084()
 	assertEquals "_cj_conf_arg10" "dual" "$CJCONF_CALL1_ARG10"
 	assertEquals "_cj_single_install calls" "0" "$CJSINGLE_CALLS"
 	assertEquals "_cj_interal_conf calls" "0" "$CJICONF_CALLS"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 
@@ -940,7 +940,7 @@ test_pot_create_120()
 	assertEquals "_cj_interal_conf arg2" "single" "$CJICONF_CALL1_ARG2"
 	assertEquals "_cj_interal_conf arg3" "0" "$CJICONF_CALL1_ARG3"
 	assertEquals "_cj_interal_conf arg4" "" "$CJICONF_CALL1_ARG4"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_121()
@@ -975,7 +975,7 @@ test_pot_create_121()
 	assertEquals "_cj_interal_conf arg2" "single" "$CJICONF_CALL1_ARG2"
 	assertEquals "_cj_interal_conf arg3" "0" "$CJICONF_CALL1_ARG3"
 	assertEquals "_cj_interal_conf arg4" "10.1.2.3" "$CJICONF_CALL1_ARG4"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 }
 
 test_pot_create_122()
@@ -1009,7 +1009,7 @@ test_pot_create_122()
 	assertEquals "_cj_interal_conf arg2" "single" "$CJICONF_CALL1_ARG2"
 	assertEquals "_cj_interal_conf arg3" "0" "$CJICONF_CALL1_ARG3"
 	assertEquals "_cj_interal_conf arg4" "" "$CJICONF_CALL1_ARG4"
-	assertEquals "_cj_flv calls" "0" "$CJFLV_CALLS"
+	assertEquals "_exec_flv calls" "0" "$EXEC_FLV_CALLS"
 	assertEquals "_potnet calls" "0" "$POTNET_CALLS"
 }
 
@@ -1027,8 +1027,8 @@ setUp()
 	CJCONF_CALL1_ARG10=
 	CJICONF_CALLS=0
 	CJICONF_CALL1_ARG4=
-	CJFLV_CALLS=0
-	CJFLV_CALL1_ARG2=
+	EXEC_FLV_CALLS=0
+	EXEC_FLV_CALL1_ARG2=
 	HELP_CALLS=0
 	ISVNETAVAIL_CALLS=0
 	ISPOTNETAVAIL_CALLS=0


### PR DESCRIPTION
Being able to run flavour scripts with the `clone` command enables a use case to easily re-use pots.

Currently, this scenario won't allow image creation, because exporting images doesn't work with cloned pots. 