### PR TITLE
Make copy-in more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - start: add support for custom dns resolver
 - init: create backup of rc.conf and pf.conf before to apply pot related changes
 - info: -B instead of -b for private bridge information
+- copy-in: copy is executed in the jail environment, to avoid soft-link related issues in the destination path
+- copy-in: with running pots, a -F flag is needed to force the copy, an operation that is discouraged for security reasons
 
 ### Removed
 - create-dns: remove this already deprecated command, leaving the user to create a dns for the public bridge

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -1059,7 +1059,7 @@ pot-cmd()
 	. "${_POT_INCLUDE}/${_cmd}.sh"
 	_func=pot-${_cmd}
 	case "$_cmd" in
-		create|import|clone|create-private-bridge|prepare)
+		create|import|clone|create-private-bridge|prepare|copy-in)
 			if [ "$_POT_RECURSIVE" = "1" ]; then
 				logger -p "${POT_LOG_FACILITY}".info -t pot "$_func $*"
 				$_func "$@"

--- a/share/pot/copy-in.sh
+++ b/share/pot/copy-in.sh
@@ -7,6 +7,7 @@ copy-in-help()
 	echo "pot copy-in [-hv] -p pot -s source -d destination"
 	echo '  -h print this help'
 	echo '  -v verbose'
+	echo '  -F force copy operation for running jails (can partially expose the host file system)'
 	echo '  -p pot : the working pot'
 	echo '  -s source : the file to be added component to be added'
 	echo '  -d destination : the final location inside the pot'
@@ -16,7 +17,7 @@ copy-in-help()
 _source_validation()
 {
 	# shellcheck disable=SC2039
-	local _pname _source _destination
+	local _source
 	_source="$1"
 	if [ -f "$_source" ] || [ -d "$_source" ]; then
 		if [ -r "$_source" ]; then
@@ -30,21 +31,48 @@ _source_validation()
 	fi
 }
 
+_mount_source_into_potroot()
+{
+	# shellcheck disable=SC2039
+	local _source _proot _source_mnt
+	_source="$1"
+	_proot="$2"
+	if [ -f "$_source" ]; then
+		_source_mnt="$( dirname "$_source" )"
+	else
+		_source_mnt="$_source"
+	fi
+
+	if ! mkdir "$_proot/tmp/tmp" ; then
+		_error "Failed to created the temporary mount point inside the pot"
+		return 1
+	fi
+	if ! mount_nullfs -o ro "$_source_mnt" "$_proot/tmp/tmp" ; then
+		_error "Failed to mount source inside the pot"
+	fi
+}
+
 # shellcheck disable=SC2039
 pot-copy-in()
 {
-	local _pname _source _destination _to_be_umount _rc
+	local _pname _source _destination _to_be_umount _rc _force _proot _cp_opt
 	OPTIND=1
 	_pname=
 	_destination=
-	while getopts "hvs:d:p:" _o ; do
+	_force=
+	_cp_opt="-a"
+	while getopts "hvs:d:p:F" _o ; do
 		case "$_o" in
 		h)
 			copy-in-help
 			return 0
 			;;
+		F)
+			_force="YES"
+			;;
 		v)
 			_POT_VERBOSITY=$(( _POT_VERBOSITY + 1))
+			_cp_opt="-va"
 			;;
 		s)
 			_source="$OPTARG"
@@ -95,20 +123,50 @@ pot-copy-in()
 		copy-in-help
 		return 1
 	fi
-	if ! _is_pot_running "$_pname" ; then 
+	if _is_pot_running "$_pname" ; then
+		if [ "$_force" != "YES" ]; then
+			_error "Copying files on a running pot is discouraged, it can partially expose the host file system to the jail"
+			_info "Using the -F flag, the operation can be executed anyway, but we disagree"
+			return 1
+		else
+			_debug "Copying files on a running pot allowed, because of the -F flag"
+		fi
+	else
 		_pot_mount "$_pname"
 		_to_be_umount=1
 	fi
-	if _is_verbose ; then
-		_cp_opt="-va"
-	else
-		_cp_opt="-a"
+	_proot=${POT_FS_ROOT}/jails/$_pname/m
+	if ! _mount_source_into_potroot "$_source" "$_proot" ; then
+		if [ "$_to_be_umount" = "1" ]; then
+			_pot_umount "$_pname"
+		fi
+		return 1
 	fi
-	if cp "$_cp_opt" "$_source" "${POT_FS_ROOT}/jails/$_pname/m/$_destination" ; then
-		_debug "Source $_source copied in the pot $_pname"
-		_rc=0
+	if [ -f "$_source" ]; then
+		_cp_source="/tmp/tmp/$( basename "$_source" )"
 	else
-		_error "Source $_source NOT copied because of an error"
+		_cp_source=/tmp/tmp
+	fi
+	if _is_pot_running "$_pname" ; then
+		if jexec "$_pname" /bin/cp "$_cp_opt" "/tmp/tmp/$_cp_source" "$_destination" ; then
+			_debug "Source $_source copied in the pot $_pname"
+			_rc=0
+		else
+			_error "Source $_source NOT copied because of an error"
+			_rc=1
+		fi
+	else
+		if jail -c path="$_proot" command=/bin/cp "$_cp_opt" "/tmp/tmp/$_cp_source" "$_destination" ; then
+			_debug "Source $_source copied in the pot $_pname"
+			_rc=0
+		else
+			_error "Source $_source NOT copied because of an error"
+			_rc=1
+		fi
+	fi
+
+	if umount "$_proot/tmp/tmp" ; then
+		_error "Failed to unmount the source tmp folder from the pot"
 		_rc=1
 	fi
 	if [ "$_to_be_umount" = "1" ]; then

--- a/share/pot/copy-in.sh
+++ b/share/pot/copy-in.sh
@@ -109,7 +109,6 @@ pot-copy-in()
 		_error "The destination has to be an absolute pathname"
 		return 1
 	fi
-	_destination="${_destination#/}"
 
 	if ! _is_pot "$_pname" ; then
 		_error "pot $_pname is not valid"
@@ -148,7 +147,7 @@ pot-copy-in()
 		_cp_source=/tmp/tmp
 	fi
 	if _is_pot_running "$_pname" ; then
-		if jexec "$_pname" /bin/cp "$_cp_opt" "/tmp/tmp/$_cp_source" "$_destination" ; then
+		if jexec "$_pname" /bin/cp "$_cp_opt" "$_cp_source" "$_destination" ; then
 			_debug "Source $_source copied in the pot $_pname"
 			_rc=0
 		else
@@ -156,7 +155,7 @@ pot-copy-in()
 			_rc=1
 		fi
 	else
-		if jail -c path="$_proot" command=/bin/cp "$_cp_opt" "/tmp/tmp/$_cp_source" "$_destination" ; then
+		if jail -c path="$_proot" command=/bin/cp "$_cp_opt" "$_cp_source" "$_destination" ; then
 			_debug "Source $_source copied in the pot $_pname"
 			_rc=0
 		else
@@ -165,7 +164,7 @@ pot-copy-in()
 		fi
 	fi
 
-	if umount "$_proot/tmp/tmp" ; then
+	if ! umount "$_proot/tmp/tmp" ; then
 		_error "Failed to unmount the source tmp folder from the pot"
 		_rc=1
 	fi

--- a/share/zsh/site-functions/_pot
+++ b/share/zsh/site-functions/_pot
@@ -197,6 +197,7 @@ _pot() {
 					_arguments -s \
 						'-h[Show help]' \
 						'-v[Verbose output]' \
+						'-F[Force with running pots]' \
 						'-p[pot name]:pot name:_pot_pots' \
 						'-s[source]:source:_normal' \
 						'-d[destination]:destination:_normal'

--- a/tests/CI/run.sh
+++ b/tests/CI/run.sh
@@ -192,7 +192,7 @@ fscomp_test() {
 
 copy_test() {
 	local name=$1
-	if pot copy-in -p $name -s /etc/protocols -d /root ; then
+	if ! pot copy-in -p $name -s /etc/protocols -d /root ; then
 		error $name copy-in
 	fi
 }
@@ -442,10 +442,10 @@ pot_test() {
 	if [ $4 = "ipv6" ] && [ $3 = "private-bridge" ]; then
 		return
 	fi
+	copy_test $name
 	snap_test $name $1
 	export_test $name $1
 	fscomp_test $name
-	copy_test $name
 	startstop_test $name $3 $4 check-copy-in
 	local new_name=${name}_new
 	rename_test $name $new_name

--- a/tests/CI/run.sh
+++ b/tests/CI/run.sh
@@ -192,7 +192,7 @@ fscomp_test() {
 
 copy_test() {
 	local name=$1
-	if pot copy-in -p $name -s /etc/os-version -d /root ; then
+	if pot copy-in -p $name -s /etc/protocols -d /root ; then
 		error $name copy-in
 	fi
 }
@@ -220,7 +220,7 @@ startstop_test() {
 		error $name start
 	fi
 	if [ "$4" = "check-copy-in" ]; then
-		if ! jexec $name test -f /root/os-version ; then
+		if ! jexec $name test -f /root/protocols ; then
 			error $name no-copied-file
 		fi
 	fi

--- a/tests/CI/run.sh
+++ b/tests/CI/run.sh
@@ -190,6 +190,13 @@ fscomp_test() {
 	fi
 }
 
+copy_test() {
+	local name=$1
+	if pot copy-in -p $name -s /etc/os-version -d /root ; then
+		error $name copy-in
+	fi
+}
+
 # $1 pot name
 _get_ip() {
 	local name=$1
@@ -211,6 +218,11 @@ startstop_test() {
 	fi
 	if ! pot start $name ; then
 		error $name start
+	fi
+	if [ "$4" = "check-copy-in" ]; then
+		if ! jexec $name test -f /root/os-version ; then
+			error $name no-copied-file
+		fi
 	fi
 	# runtime checks
 	if [ "$(pot show | grep -c $name)" -ne 1 ]; then
@@ -433,7 +445,8 @@ pot_test() {
 	snap_test $name $1
 	export_test $name $1
 	fscomp_test $name
-	startstop_test $name $3 $4
+	copy_test $name
+	startstop_test $name $3 $4 check-copy-in
 	local new_name=${name}_new
 	rename_test $name $new_name
 	startstop_test $new_name $3 $4

--- a/tests/copy-in1.sh
+++ b/tests/copy-in1.sh
@@ -2,8 +2,33 @@
 
 # system utilities stubs
 
-cp() {
-	__monitor CP "$@"
+if [ "$(uname)" = "Linux" ]; then
+	TEST=/usr/bin/[
+else
+	TEST=/bin/[
+fi
+
+[()
+{
+	if ${TEST} "$1" = "-f" ]; then
+		if ${TEST} "$2" = "test-file" ]; then
+			return 0 # false
+		fi
+	fi
+	${TEST} "$@"
+	return $?
+}
+
+jexec() {
+	__monitor JEXEC "$@"
+}
+
+jail() {
+	__monitor JAIL "$@"
+}
+
+umount() {
+	__monitor UMOUNT "$@"
 }
 
 # UUT
@@ -28,6 +53,11 @@ _source_validation()
 		return 0 # true
 	fi
 	return 1 # false
+}
+
+_mount_source_into_potroot()
+{
+	return 0 # true
 }
 
 _pot_mount()
@@ -144,6 +174,19 @@ test_pot_copy_in_005()
 	assertEquals "_source_validation calls" "1" "$SRCVALID_CALLS"
 }
 
+test_pot_copy_in_006()
+{
+	pot-copy-in -p test-pot-run -s test-file -d /test-mnt
+	assertEquals "Exit rc" "1" "$?"
+	assertEquals "Help calls" "0" "$HELP_CALLS"
+	assertEquals "_is_pot calls" "1" "$ISPOT_CALLS"
+	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
+	assertEquals "_source_validation calls" "1" "$SRCVALID_CALLS"
+	assertEquals "_pot_mount calls" "0" "$PMOUNT_CALLS"
+	assertEquals "_jexec calls" "0" "$JEXEC_CALLS"
+	assertEquals "_jail calls" "0" "$JAIL_CALLS"
+}
+
 test_pot_copy_in_020()
 {
 	pot-copy-in -p test-pot -s test-file -d /test-mnt
@@ -154,16 +197,17 @@ test_pot_copy_in_020()
 	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
 	assertEquals "_source_validation calls" "1" "$SRCVALID_CALLS"
 	assertEquals "_pot_mount calls" "1" "$PMOUNT_CALLS"
-	assertEquals "_cp calls" "1" "$CP_CALLS"
-	assertEquals "_cp args" "-a" "$CP_CALL1_ARG1"
-	assertEquals "_cp args" "test-file" "$CP_CALL1_ARG2"
-	assertEquals "_cp args" "/tmp/jails/test-pot/m/test-mnt" "$CP_CALL1_ARG3"
+	assertEquals "_jexec calls" "0" "$JEXEC_CALLS"
+	assertEquals "_jail calls" "1" "$JAIL_CALLS"
+	assertEquals "_jail args" "-c" "$JAIL_CALL1_ARG1"
+	assertEquals "_jail args" "/tmp/tmp/test-file" "$JAIL_CALL1_ARG5"
+	assertEquals "_jail args" "/test-mnt" "$JAIL_CALL1_ARG6"
 	assertEquals "_pot_umount calls" "1" "$PUMOUNT_CALLS"
 }
 
 test_pot_copy_in_021()
 {
-	pot-copy-in -p test-pot-run -s test-file -d /test-mnt
+	pot-copy-in -p test-pot-run -s test-file -d /test-mnt -F
 	assertEquals "Exit rc" "0" "$?"
 	assertEquals "Help calls" "0" "$HELP_CALLS"
 	assertEquals "Error calls" "0" "$ERROR_CALLS"
@@ -171,16 +215,18 @@ test_pot_copy_in_021()
 	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
 	assertEquals "_source_validation calls" "1" "$SRCVALID_CALLS"
 	assertEquals "_pot_mount calls" "0" "$PMOUNT_CALLS"
-	assertEquals "_cp calls" "1" "$CP_CALLS"
-	assertEquals "_cp args" "-a" "$CP_CALL1_ARG1"
-	assertEquals "_cp args" "test-file" "$CP_CALL1_ARG2"
-	assertEquals "_cp args" "/tmp/jails/test-pot-run/m/test-mnt" "$CP_CALL1_ARG3"
+	assertEquals "_jexec calls" "1" "$JEXEC_CALLS"
+	assertEquals "_jexec args" "test-pot-run" "$JEXEC_CALL1_ARG1"
+	assertEquals "_jexec args" "-a" "$JEXEC_CALL1_ARG3"
+	assertEquals "_jexec args" "/tmp/tmp/test-file" "$JEXEC_CALL1_ARG4"
+	assertEquals "_jexec args" "/test-mnt" "$JEXEC_CALL1_ARG5"
+	assertEquals "_jail calls" "0" "$JAIL_CALLS"
 	assertEquals "_pot_umount calls" "0" "$PUMOUNT_CALLS"
 }
 
 test_pot_copy_in_022()
 {
-	pot-copy-in -p test-pot-run -s test-file -d /test-mnt -v
+	pot-copy-in -p test-pot-run -s test-file -d /test-mnt -vF
 	assertEquals "Exit rc" "0" "$?"
 	assertEquals "Help calls" "0" "$HELP_CALLS"
 	assertEquals "Error calls" "0" "$ERROR_CALLS"
@@ -188,10 +234,12 @@ test_pot_copy_in_022()
 	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
 	assertEquals "_source_validation calls" "1" "$SRCVALID_CALLS"
 	assertEquals "_pot_mount calls" "0" "$PMOUNT_CALLS"
-	assertEquals "_cp calls" "1" "$CP_CALLS"
-	assertEquals "_cp args" "-va" "$CP_CALL1_ARG1"
-	assertEquals "_cp args" "test-file" "$CP_CALL1_ARG2"
-	assertEquals "_cp args" "/tmp/jails/test-pot-run/m/test-mnt" "$CP_CALL1_ARG3"
+	assertEquals "_jexec calls" "1" "$JEXEC_CALLS"
+	assertEquals "_jexec args" "test-pot-run" "$JEXEC_CALL1_ARG1"
+	assertEquals "_jexec args" "-va" "$JEXEC_CALL1_ARG3"
+	assertEquals "_jexec args" "/tmp/tmp/test-file" "$JEXEC_CALL1_ARG4"
+	assertEquals "_jexec args" "/test-mnt" "$JEXEC_CALL1_ARG5"
+	assertEquals "_jail calls" "0" "$JAIL_CALLS"
 	assertEquals "_pot_umount calls" "0" "$PUMOUNT_CALLS"
 }
 
@@ -205,19 +253,24 @@ test_pot_copy_in_023()
 	assertEquals "_is_uid0 calls" "1" "$ISUID0_CALLS"
 	assertEquals "_source_validation calls" "1" "$SRCVALID_CALLS"
 	assertEquals "_pot_mount calls" "1" "$PMOUNT_CALLS"
-	assertEquals "_cp calls" "1" "$CP_CALLS"
-	assertEquals "_cp args" "-va" "$CP_CALL1_ARG1"
-	assertEquals "_cp args" "test-dir" "$CP_CALL1_ARG2"
-	assertEquals "_cp args" "/tmp/jails/test-pot/m/test-mnt" "$CP_CALL1_ARG3"
+	assertEquals "_jexec calls" "0" "$JEXEC_CALLS"
+	assertEquals "_jail calls" "1" "$JAIL_CALLS"
+	assertEquals "_jail args" "-c" "$JAIL_CALL1_ARG1"
+	assertEquals "_jail args" "/tmp/tmp" "$JAIL_CALL1_ARG5"
+	assertEquals "_jail args" "/test-mnt" "$JAIL_CALL1_ARG6"
 	assertEquals "_pot_umount calls" "1" "$PUMOUNT_CALLS"
 }
 
 setUp()
 {
 	common_setUp
+	ERROR_DEBUG="NO"
+	DEBUG_DEBUG="NO"
 	HELP_CALLS=0
 	SRCVALID_CALLS=0
-	CP_CALLS=0
+	JAIL_CALLS=0
+	JEXEC_CALLS=0
+	UMOUNT_CALLS=0
 	PMOUNT_CALLS=0
 	PUMOUNT_CALLS=0
 


### PR DESCRIPTION
the copy operation in copy-in should be executed inside the jail, for safety and security reasons (for instance, a symbolic link with an absolute pathname can have undesired effects).

This patch let cp to be executed inside the jail, temporarily mounting the source file/folder via nullfs