### PR TITLE
Add  -p everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - info: -s to list available snapshots of a pot
 - clone: -s flag to explicitly choose the snapshot to clone
 - architecture: remove limitation of amd64 as the only architecture supported (#143 by jmg@)
+- start/stop/term/run: add support to -p potname on those commands, the only one not supporting it
 
 ### Changed
 - hostname: max default length for hostname set to 64 (#118)

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC3033
 start-help()
 {
-	echo "pot start [-h] [potname]"
+	echo "pot start [-h] [-p] potname"
 	echo '  -h print this help'
 	echo '  -v verbose'
 	echo '  -s take a snapshot before to start'
@@ -562,8 +562,9 @@ pot-start()
 	# shellcheck disable=SC3043
 	local _pname _snap
 	_snap=none
+	_pname=
 	OPTIND=1
-	while getopts "hvsS" _o ; do
+	while getopts "hvsSp:" _o ; do
 		case "$_o" in
 		h)
 			start-help
@@ -578,13 +579,18 @@ pot-start()
 		S)
 			_snap=full
 			;;
+		p)
+			_pname="$OPTARG"
+			;;
 		*)
 			start-help
 			${EXIT} 1
 			;;
 		esac
 	done
-	_pname="$( eval echo \$$OPTIND)"
+	if [ -z "$_pname" ]; then
+		_pname="$( eval echo \$$OPTIND)"
+	fi
 	if [ -z "$_pname" ]; then
 		_error "A pot name is mandatory"
 		start-help

--- a/share/pot/stop.sh
+++ b/share/pot/stop.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC3033
 stop-help()
 {
-	echo "pot stop [-hv] [potname]"
+	echo "pot stop [-hv] [-p] potname"
 	echo '  -h print this help'
 	echo '  -v verbose'
 	echo '  potname : the pot that has to stop'
@@ -147,9 +147,10 @@ pot-stop()
 {
 	# shellcheck disable=SC3043
 	local _pname
+	_pname=
 
 	OPTIND=1
-	while getopts "hv" _o; do
+	while getopts "hvp:" _o; do
 		case "$_o" in
 		h)
 			stop-help
@@ -158,13 +159,18 @@ pot-stop()
 		v)
 			_POT_VERBOSITY=$(( _POT_VERBOSITY + 1))
 			;;
+		p)
+			_pname="$OPTARG"
+			;;
 		?)
 			stop-help
 			${EXIT} 1
 			;;
 		esac
 	done
-	_pname="$( eval echo \$$OPTIND)"
+	if [ -z "$_pname" ]; then
+		_pname="$( eval echo \$$OPTIND)"
+	fi
 	if [ -z "$_pname" ]; then
 		_error "A pot name is mandatory"
 		stop-help

--- a/share/pot/term.sh
+++ b/share/pot/term.sh
@@ -4,7 +4,7 @@
 # shellcheck disable=3033
 term-help()
 {
-	echo "pot term [-h] [potname]"
+	echo "pot term [-hvf] [-p] potname"
 	echo '  -h print this help'
 	echo '  -v verbose'
 	echo '  -f force: it start the pot, if it'\''s not running'
@@ -32,7 +32,7 @@ pot-term()
 	_force=
 
 	OPTIND=1
-	while getopts "hvf" _o; do
+	while getopts "hvfp:" _o; do
 		case "$_o" in
 		h)
 			term-help
@@ -44,12 +44,17 @@ pot-term()
 		f)
 			_force="YES"
 			;;
+		p)
+			_pname="$OPTARG"
+			;;
 		?)
 			break
 			;;
 		esac
 	done
-	_pname="$(eval echo \$$OPTIND)"
+	if [ -z "$_pname" ]; then
+		_pname="$(eval echo \$$OPTIND)"
+	fi
 	if [ -z "$_pname" ]; then
 		_error "A pot name is mandatory"
 		term-help


### PR DESCRIPTION
Few commands don't used any -p parameter to specify the pot to work with.
This patch fix it, while not compromising the compatibility with previous versions.