### PR TITLE
Garbage collect POSIX shared memory on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- stop: garbage collect POSIX shared memory (#150)
+- import-export: add support for layered images (#151)
 
 ## [0.12.0] 2021-05-22
 ### Added

--- a/share/pot/stop.sh
+++ b/share/pot/stop.sh
@@ -100,6 +100,14 @@ _js_stop()
 		pkill -f "$_pdir/ncat-$_pname"
 	fi
 
+	# Garbage collect POSIX shared memory
+	if command -v posixshmcontrol >/dev/null; then
+		_shm_paths=$( posixshmcontrol ls | cut -f 5 | grep "^$_pdir/" )
+		for _shm_path in $_shm_paths ; do
+			posixshmcontrol rm "$_shm_path"
+		done
+	fi
+
 	if [ -x "$_pdir/conf/poststop.sh" ]; then
 		_info "Executing the post-stop script for the pot $_pname"
 		(


### PR DESCRIPTION
Addresses parts of #150.

As `posixshmcontrol` doesn't support jails, we simply use
the path of the shared memory segment to determine if
it should be collected, based on if it matches the pot's
base directory.

Anonymous shared memory segments (SHM_ANON) won't show up in
`posixshmcontrol`, but it seems like those are garbage
collected reliably when the process that created them
exits.

(Also contains CHANGELOG entry for layered images)