### PR TITLE
Prevent stopping non-persistent jails twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- start/stop: prevent stopping non-persistent jails twice (#152)
 
 ## [0.12.0] 2021-05-22
 ### Added

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -541,13 +541,17 @@ _js_start()
 			"${POT_FS_ROOT}/jails/$_pname"/conf/prestart.sh
 		)
 	fi
+
+	rm -f "/tmp/pot_stopped_${_pname}"
 	_bg_start "$_pname" &
 	_info "Starting the pot $_pname"
 	# shellcheck disable=SC2086
 	jail -c -J "/tmp/${_pname}.jail.conf" $_param exec.start="$_cmd"
 	sleep 1
 	if ! _is_pot_running "$_pname" ; then
-		start-cleanup "$_pname" "${_iface}"
+		if [ ! -e "/tmp/pot_stopped_${_pname}" ]; then
+			start-cleanup "$_pname" "${_iface}"
+		fi
 		if [ "$_persist" = "NO" ]; then
 			return 0
 		else

--- a/share/pot/stop.sh
+++ b/share/pot/stop.sh
@@ -44,6 +44,7 @@ _js_stop()
 			)
 		fi
 		_debug "Stop the pot $_pname"
+		touch "/tmp/pot_stopped_${_pname}"
 		jail -q -r "$_pname"
 		if [ -n "$_epair" ]; then
 			_debug "Remove ${_epair%b}[a|b] network interfaces"
@@ -109,7 +110,7 @@ _js_stop()
 		)
 	fi
 	rm -f "/tmp/pot_${_pname}_pfrules"
-	rm -f "/tmp/pot_environment_$_pname.sh"
+	rm -f "/tmp/pot_environment_${_pname}.sh"
 	return 0 # true
 }
 


### PR DESCRIPTION
This aims to address #152.

The problem at hand isn't really to prevent `pot stop` from
running in parallel (this could be handled on a global level),
but to prevent running "_js_stop" in `pot start`, after a
non-persistent jail was stopped.

The solution is very simple, as the use case this is about is:
1. pot stop is called
2. jail -r is called
3. pot start continues and calls "_js_stop"

By removing a file (and touching it when running "_js_stop")
this can be prevented without having to use real lock files.

Note: Given the number of files pot creates, it might make sense
to start using a subdirectory called _/tmp/pot_.