### PR TITLE
Styles fixes

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,6 +1,6 @@
 name: Shellcheck
 
-on: [push]
+on: [ pull_request ]
 
 jobs:
   shellcheck:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- import-export: add support for layered images (#151)
+
+### Fixed
 - start/stop: prevent stopping non-persistent jails twice (#152)
 - stop: garbage collect POSIX shared memory (#150)
-- import-export: add support for layered images (#151)
 
 ## [0.12.0] 2021-05-22
 ### Added


### PR DESCRIPTION
Small re-style in the Changelog (to adhere to the changelog standard)
While here, enable shellcheck action for PRs, instead of push, otherwise the output of PRs originated from forks is not visible.

FYI: @grembo 