### PR TITLE
Extending flavour dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - import-export: add support for layered images (#151)
 - POT_TMP: add a parameter to select the folder used to create temporary files
+- flavour: -f option support a full pathname (#161)
 
 ### Changed
 - start: simplify startup, use jexec to run pot.cmd (#150)
+- flavour: the current directory is added to the flavour search path (#161)
 
 ### Fixed
 - start/stop: prevent stopping non-persistent jails twice (#152)

--- a/share/pot/clone.sh
+++ b/share/pot/clone.sh
@@ -305,10 +305,6 @@ pot-clone()
 				_autosnap="YES"
 				;;
 			f)
-				if ! _is_flavourdir ; then
-					_error "The flavour directory is missing"
-					${EXIT} 1
-				fi
 				if _is_flavour "$OPTARG" ; then
 					if [ -z "$_flv" ]; then
 						_flv="$OPTARG"

--- a/share/pot/common-flv.sh
+++ b/share/pot/common-flv.sh
@@ -117,7 +117,7 @@ _exec_flv()
 		pot-cmd start "$_pname"
 		cp -v "${_flv_script}" "$_pdir/m/tmp"
 		_debug "Executing $_flv script on $_pname"
-		if ! jexec "$_pname" "/tmp/${_flv_script}" "$_pname" ; then
+		if ! jexec "$_pname" "/tmp/$(basename "${_flv_script}")" "$_pname" ; then
 			_error "create: flavour $_flv failed (script)"
 			return 1
 		fi

--- a/share/pot/common-flv.sh
+++ b/share/pot/common-flv.sh
@@ -34,7 +34,11 @@ _get_flavour_cmd_file()
     # shellcheck disable=SC3043
     local _flv_name
 	_flv_name="$1"
-	if [ -f "$_flv_name" ] && [ -r "$_flv_name" ] && [ "$_flv_name" = "${_flv_name%%.sh}" ]; then ## it's a cmd file path name
+	# if the flavor name ends with .sh return immediately
+	if [ "$_flv_name" != "${_flv_name%%.sh}" ]; then
+		return
+	fi
+	if [ -f "$_flv_name" ] && [ -r "$_flv_name" ]; then ## it's a cmd file path name
 		echo "$_flv_name"
 	elif [ -f "./$_flv_name" ] && [ -r "./$_flv_name" ]; then
 		echo "./$_flv_name"

--- a/share/pot/common-flv.sh
+++ b/share/pot/common-flv.sh
@@ -82,12 +82,13 @@ _flv_set_cmd()
 _exec_flv()
 {
 	# shellcheck disable=SC3043
-	local _pname _flv _pdir
+	local _pname _flv _pdir _flv_cmd_file _flv_script
 	_pname=$1
 	_flv=$2
 	_pdir=${POT_FS_ROOT}/jails/$_pname
 	_debug "Flavour: $_flv"
-	if [ -r "${_POT_FLAVOUR_DIR}/${_flv}" ]; then
+	_flv_cmd_file="$( _get_flavour_cmd_file "$_flv" )"
+	if [ -n "${_flv_cmd_file}" ]; then
 		_debug "Executing $_flv pot commands on $_pname"
 		while read -r line ; do
 			# shellcheck disable=SC2086
@@ -104,14 +105,15 @@ _exec_flv()
 			else
 				_error "Flavor $_flv: line $line not valid - ignoring"
 			fi
-		done < "${_POT_FLAVOUR_DIR}/${_flv}"
+		done < "${_flv_cmd_file}"
 	fi
-	if [ -x "${_POT_FLAVOUR_DIR}/${_flv}.sh" ]; then
+	_flv_script="$( _get_clavour_script "$_flv" )"
+	if [ -n "${_flv_script}" ]; then
 		_debug "Starting $_pname pot for the initial bootstrap"
 		pot-cmd start "$_pname"
 		cp -v "${_POT_FLAVOUR_DIR}/${_flv}.sh" "$_pdir/m/tmp"
 		_debug "Executing $_flv script on $_pname"
-		if ! jexec "$_pname" "/tmp/${_flv}.sh" "$_pname" ; then
+		if ! jexec "$_pname" "/tmp/${_flv_script}" "$_pname" ; then
 			_error "create: flavour $_flv failed (script)"
 			return 1
 		fi

--- a/share/pot/common-flv.sh
+++ b/share/pot/common-flv.sh
@@ -111,11 +111,11 @@ _exec_flv()
 			fi
 		done < "${_flv_cmd_file}"
 	fi
-	_flv_script="$( _get_clavour_script "$_flv" )"
+	_flv_script="$( _get_flavour_script "$_flv" )"
 	if [ -n "${_flv_script}" ]; then
 		_debug "Starting $_pname pot for the initial bootstrap"
 		pot-cmd start "$_pname"
-		cp -v "${_POT_FLAVOUR_DIR}/${_flv}.sh" "$_pdir/m/tmp"
+		cp -v "${_flv_script}" "$_pdir/m/tmp"
 		_debug "Executing $_flv script on $_pname"
 		if ! jexec "$_pname" "/tmp/${_flv_script}" "$_pname" ; then
 			_error "create: flavour $_flv failed (script)"

--- a/share/pot/common-flv.sh
+++ b/share/pot/common-flv.sh
@@ -1,5 +1,67 @@
 #!/bin/sh
 
+# $1 flavour name
+_is_flavour()
+{
+    # shellcheck disable=SC3043
+    local _flv_name
+	_flv_name="$1"
+	if [ -n "$( _get_flavour_script "$_flv_name" )" ] ||
+		[ -n "$( _get_flavour_cmd_file "$_flv_name" )" ]; then
+		return 0 # true
+	fi
+	return 1 # false
+}
+
+_get_flavour_script()
+{
+    # shellcheck disable=SC3043
+    local _flv_name
+	_flv_name="$1"
+	if [ -f "$_flv_name" ] && [ -x "$_flv_name" ] && [ "$_flv_name" != "${_flv_name%%.sh}" ]; then ## it's a script path name
+		echo "$_flv_name"
+	elif [ -f "$_flv_name.sh" ] && [ -x "$_flv_name.sh" ];  then ## it's a path name
+		echo "$_flv_name.sh"
+	elif [ -f "./$_flv_name.sh" ] && [ -x "./$_flv_name.sh" ]; then
+		echo "./$_flv_name.sh"
+	elif [ -f "${_POT_FLAVOUR_DIR}/$_flv_name.sh" ] || [ -x "${_POT_FLAVOUR_DIR}/$_flv_name.sh" ]; then
+		echo "${_POT_FLAVOUR_DIR}/$_flv_name.sh"
+	fi
+}
+
+_get_flavour_cmd_file()
+{
+    # shellcheck disable=SC3043
+    local _flv_name
+	_flv_name="$1"
+	if [ -f "$_flv_name" ] && [ -r "$_flv_name" ] && [ "$_flv_name" = "${_flv_name%%.sh}" ]; then ## it's a cmd file path name
+		echo "$_flv_name"
+	elif [ -f "./$_flv_name" ] && [ -r "./$_flv_name" ]; then
+		echo "./$_flv_name"
+	elif [ -f "${_POT_FLAVOUR_DIR}/$_flv_name" ] || [ -r "${_POT_FLAVOUR_DIR}/$_flv_name" ]; then
+		echo "${_POT_FLAVOUR_DIR}/$_flv_name"
+	fi
+}
+
+# $1 the cmd
+# all other parameter will be ignored
+# tested
+_is_cmd_flavorable()
+{
+    # shellcheck disable=SC3043
+    local _cmd
+    _cmd=$1
+    case $_cmd in
+        add-dep|set-attribute|\
+        copy-in|mount-in|\
+        set-rss|export-ports|\
+        set-cmd|set-env)
+            return 0
+            ;;
+    esac
+    return 1 # false
+}
+
 # Special version of set-cmd usable only for flavours
 # $1 : pot name
 # $2 : the set-cmd line in the file

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -180,15 +180,6 @@ _is_init()
 	fi
 }
 
-# checks if the flavour dir is set up and exist
-_is_flavourdir()
-{
-	if [ -z "${_POT_FLAVOUR_DIR}" ] || [ ! -d "${_POT_FLAVOUR_DIR}" ]; then
-		return 1 # false
-	fi
-	return 0 # true
-}
-
 # check the POT_TMP directory
 # if missing, it will initialize it
 _is_pot_tmp_dir()
@@ -652,15 +643,6 @@ _is_valid_potname()
 	fi
 }
 
-# $1 flavour name
-_is_flavour()
-{
-	if [ -r "${_POT_FLAVOUR_DIR}/$1" ] || [ -x "${_POT_FLAVOUR_DIR}/$1.sh" ]; then
-		return 0 # true
-	fi
-	return 1 # false
-}
-
 # $1 the element to search
 # $2.. the list
 # tested
@@ -747,25 +729,6 @@ _set_command()
 		_cmd2="$( echo "$_cmd1" | sed 's/"$//' )"
 		echo "pot.cmd=$_cmd2" >> "$_cdir/pot.conf"
 	fi
-}
-
-# $1 the cmd
-# all other parameter will be ignored
-# tested
-_is_cmd_flavorable()
-{
-	# shellcheck disable=SC3043
-	local _cmd
-	_cmd=$1
-	case $_cmd in
-		add-dep|set-attribute|\
-		copy-in|mount-in|\
-		set-rss|export-ports|\
-		set-cmd|set-env)
-			return 0
-			;;
-	esac
-	return 1 # false
 }
 
 # tested

--- a/share/pot/create.sh
+++ b/share/pot/create.sh
@@ -565,10 +565,6 @@ pot-create()
 			esac
 			;;
 		f)
-			if ! _is_flavourdir ; then
-				_error "The flavour directory is missing"
-				${EXIT} 1
-			fi
 			if _is_flavour "$OPTARG" ; then
 				if [ -z "$_flv" ]; then
 					_flv=$OPTARG

--- a/tests/common-flv1.sh
+++ b/tests/common-flv1.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+# system utilities stubs
+. monitor.sh
+
+# UUT
+. ../share/pot/common-flv.sh
+
+# app specific stubs
+
+_get_flavour_cmd_file()
+{
+	case "$1" in
+		test)
+			echo test ;;
+		testnoscript)
+			echo testnoscript ;;
+		*)
+			;;
+	esac
+}
+
+_get_flavour_script()
+{
+	case "$1" in
+		test)
+			echo test.sh ;;
+		testnocmd)
+			echo testnocmd.sh ;;
+		*)
+			;;
+	esac
+}
+
+test_is_cmd_flavorable_01()
+{
+	_is_cmd_flavorable
+	assertNotEquals "$?" "0"
+
+	_is_cmd_flavorable help
+	assertNotEquals "$?" "0"
+
+	_is_cmd_flavorable help create
+	assertNotEquals "$?" "0"
+
+	_is_cmd_flavorable create -p help
+	assertNotEquals "$?" "0"
+
+	_is_cmd_flavorable add-fscomp
+	assertNotEquals "$?" "0"
+
+	_is_cmd_flavorable add-file
+	assertNotEquals "$?" "0"
+}
+
+test_is_cmd_flavorable_02()
+{
+	_is_cmd_flavorable add-dep
+	assertEquals "$?" "0"
+
+	_is_cmd_flavorable add-dep -v -p me -P you
+	assertEquals "$?" "0"
+
+	_is_cmd_flavorable set-rss
+	assertEquals "$?" "0"
+
+	_is_cmd_flavorable copy-in
+	assertEquals "$?" "0"
+
+	_is_cmd_flavorable mount-in
+	assertEquals "$?" "0"
+}
+
+test_is_flavour_001()
+{
+	assertTrue "_is_flavour test"
+	assertTrue "_is_flavour testnoscript"
+	assertTrue "_is_flavour testnocmd"
+	assertFalse "_is_flavour notest"
+}
+
+setUp()
+{
+	_POT_VERBOSITY=1
+}
+
+. shunit/shunit2

--- a/tests/common-stub.sh
+++ b/tests/common-stub.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 . ../share/pot/common.sh
+. ../share/pot/common-flv.sh
 . ../share/pot/network.sh
 EXIT="return"
 

--- a/tests/common1.sh
+++ b/tests/common1.sh
@@ -161,46 +161,6 @@ test_umount()
 	assertEquals "/opt/distfiles" "$UMOUNT_CALL1_ARG2"
 }
 
-test_is_cmd_flavorable_01()
-{
-	_is_cmd_flavorable
-	assertNotEquals "$?" "0"
-
-	_is_cmd_flavorable help
-	assertNotEquals "$?" "0"
-
-	_is_cmd_flavorable help create
-	assertNotEquals "$?" "0"
-
-	_is_cmd_flavorable create -p help
-	assertNotEquals "$?" "0"
-
-	_is_cmd_flavorable add-fscomp
-	assertNotEquals "$?" "0"
-
-	_is_cmd_flavorable add-file
-	assertNotEquals "$?" "0"
-}
-
-test_is_cmd_flavorable_02()
-{
-	_is_cmd_flavorable add-dep
-	assertEquals "$?" "0"
-
-	_is_cmd_flavorable add-dep -v -p me -P you
-	assertEquals "$?" "0"
-
-	_is_cmd_flavorable set-rss
-	assertEquals "$?" "0"
-
-	_is_cmd_flavorable copy-in
-	assertEquals "$?" "0"
-
-	_is_cmd_flavorable mount-in
-	assertEquals "$?" "0"
-}
-
-
 test_is_rctl_available()
 {
 	_is_rctl_available


### PR DESCRIPTION
Extend what `-f` can accept to specify a flavour.

`pot` checks and accepts flavour if (following this order):
* the flavour is a valid pathname (absolute or relative)
* the files are in the local directory (`.`)
* the files are in the `_POT_FLAVOUR_DIR` directory (usually `/usr/local/etc/pot/flavours`)

close #161 