### PR TITLE
Fix ncat failing to start due to argv handling

### DIFF
--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -307,7 +307,7 @@ _js_export_ports()
 			_pdir="${POT_FS_ROOT}/jails/$_pname"
 			if [ -x "/usr/local/bin/ncat" ]; then
 				cp /usr/local/bin/ncat "$_pdir/ncat-$_pname-$_pot_port"
-				daemon -f -p "$_pdir/ncat-$_pot_port.pid" "$_pdir/ncat-$_pname-$_pot_port" -lk "${_ncat_opt}" "$_host_port" -c "/usr/local/bin/ncat $_ncat_opt $_ip $_pot_port"
+				daemon -f -p "$_pdir/ncat-$_pot_port.pid" "$_pdir/ncat-$_pname-$_pot_port" -lk $_ncat_opt "$_host_port" -c "/usr/local/bin/ncat $_ncat_opt $_ip $_pot_port"
 			else
 				_error "nmap package is missing, localhost-tunnel attribute ignored"
 			fi


### PR DESCRIPTION
I'm currently using Pot under Nomad/Consul. Recently, I've upgraded Pot on my server to 0.12.0 and noticed all my Pots are now failing health check (due to `rdr` only applies to packet incoming from an interface). After some troubleshooting, I found it was due to `ncat` no longer spawning under 0.12.0 even when `local-tunnel` is set to `YES`. 

Upon further debugging, the issue seems to be caused by a change in how Pot handles ncat arguments escaping:

https://github.com/pizzamig/pot/blob/00684875f15fd2a113650b32f7659485174b0bdf/share/pot/start.sh#L310

In this line, Pot is passing `$_ncat_opt` to the command line. However, when `$_ncat_opt` is empty, it will be treat as an empty argument being passed after `-lk`, e.g. `-lk "" 8080 -c ...` (or `["-lk", "", "8080", "-c", ...]`) so the command would error with "Ncat: Got more than one port specification".

The easiest fix here would be to unescape `$_ncat_opt`, which should be safe to do in this case (no shellcheck warnings). 