### PR TITLE
Make flavour copy-in relative to flavour dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /doc
 *.swp
+*~
 /etc/pot/pot.conf
 /etc/pot/flavours/*
 !/etc/pot/flavours/dns.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- create: New command copy-in-flv, which is the same as copy-in, but always relative to flavourdir (#173)
 
 ## [0.13.0] 2021-09-21
 ### Added


### PR DESCRIPTION
This is acomplished by changing directories (seemed least
intrusive).

This allows having:
```
copy-in -s dns.d/resolver.conf -d /etc
```
