### PR TITLE
Add flag to create copy-in destination dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- copy-in: -c option to create missing dirs on copy-in (#172)
 
 ## [0.13.0] 2021-09-21
 ### Added


### PR DESCRIPTION
If set, this creates $(dirname "$destdir"). Addresses #172.

Implementation is conservative in that it executes `mkdir` inside the pot.

Example of use:

    pot copy-in -p dnspot -s dns.d/dns.conf -cd /usr/local/etc/.
    pot copy-in -p dnspot -s dns.d/some.txt -cd /usr/local/share/some/test.txt

This also fixes a bug in _make_temp_source() which broke copy-in
functionality.