### PR TITLE
Stop logging trivial commands to syslog by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - mount-out: new command to remove or unmount a previously mount-in folder or fs
 
+### Changed
+- Stop logging trivial commands like get-rss to syslog by default (#xxx)
+
 ## [0.14.0] 2021-10-31
 ### Added
 - copy-in: -c option to create missing dirs on copy-in (#172)

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -1003,6 +1003,12 @@ pot-cmd()
 				lockf -k /tmp/pot-lock-file "$_POT_PATHNAME" "$_cmd" "$@"
 			fi
 			;;
+		config|get-attr|get-rss|info|list|ps|show|top)
+			if _is_verbose ; then
+				logger -p "${POT_LOG_FACILITY}".debug -t pot "$_func $*"
+			fi
+			$_func "$@"
+			;;
 		*)
 			logger -p "${POT_LOG_FACILITY}".info -t pot "$_func $*"
 			$_func "$@"


### PR DESCRIPTION
The main motivation was to reduce the noise in logs that resulted
from having one log line per container per second thanks to
nomad-pot-driver calling "pot get-rss" on each container.

After the change, commands that modify things will still
be logged with severity "info", while trivial commands likei
get-rss will only be logged if verbosity is set to debug
and use syslog severity "debug".

I didn't bother to wrap "info" logging into a vebosity check,
as right now it defaults to info anyway. There is probably room
for improvement here.