### PR TITLE
Inherit encryption property from parent filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - mount-out: new command to remove or unmount a previously mount-in folder or fs
 - attribute no-tmpfs: an attribute, for single dataset only, to not use tmpfs for /tmp
+- create/import: inherit ZFS encryption property from parent filesystem (#196)
 
 ### Changed
 - Stop logging trivial commands like get-rss to syslog by default (#190)

--- a/share/pot/create.sh
+++ b/share/pot/create.sh
@@ -84,7 +84,9 @@ _c_zfs_single()
 		_snap=$(_zfs_last_snap "$_dset")
 		if [ -n "$_snap" ]; then
 			_debug "Clone zfs snapshot $_dset@$_snap"
-			if ! zfs send "$_dset@$_snap" | zfs receive "$_pdset/m" ; then
+			# shellcheck disable=SC2046
+			if ! zfs send "$_dset@$_snap" | zfs receive \
+			    $(_get_zfs_receive_extra_args) "$_pdset/m" ; then
 				_error "create: zfs send/receive failed"
 				_cj_undo_create
 				return 1 # false
@@ -143,7 +145,9 @@ _c_zfs_multi()
 			_snap=$(_zfs_last_snap "$_dset/usr.local")
 			if [ -n "$_snap" ]; then
 				_debug "Import zfs snapshot $_dset/usr.local@$_snap"
-				if ! zfs send "$_dset/usr.local@$_snap" | zfs receive "$_pdset/usr.local" ; then
+				# shellcheck disable=SC2046
+				if ! zfs send "$_dset/usr.local@$_snap" | zfs receive \
+				    $(_get_zfs_receive_extra_args) "$_pdset/usr.local" ; then
 					_error "create: zfs send/receive failed"
 					_cj_undo_create
 					return 1 # false
@@ -171,7 +175,9 @@ _c_zfs_multi()
 		_snap=$(_zfs_last_snap "$_dset")
 		if [ -n "$_snap" ]; then
 			_debug "Clone zfs snapshot $_dset@$_snap"
-			if ! zfs send "$_dset@$_snap" | zfs receive "$_pdset/custom" ; then
+			# shellcheck disable=SC2046
+			if ! zfs send "$_dset@$_snap" | zfs receive \
+			    $(_get_zfs_receive_extra_args) "$_pdset/custom" ; then
 				_error "create: zfs send/receive failed"
 				_cj_undo_create
 				return 1 # false

--- a/share/pot/import.sh
+++ b/share/pot/import.sh
@@ -92,19 +92,19 @@ _import_pot()
 	_cdir="${POT_FS_ROOT}/jails/$_pname/conf"
 
 	if [ -n "$_origin_pname" ] && [ -n "$_origin_snap" ]; then
-		xzcat "${POT_CACHE}/$_filename" | zfs recv -uo \
+		# shellcheck disable=SC2046
+		xzcat "${POT_CACHE}/$_filename" | zfs receive -uo \
 		  "origin=${POT_ZFS_ROOT}/jails/$_origin_pname@$_origin_snap" \
+		  $(_get_zfs_receive_extra_args) \
 		  "${POT_ZFS_ROOT}/jails/$_pname"
 		zfs inherit mountpoint "${POT_ZFS_ROOT}/jails/$_pname/m"
 		zfs mount "${POT_ZFS_ROOT}/jails/$_pname"
 		zfs mount "${POT_ZFS_ROOT}/jails/$_pname/m"
 	else
-		xzcat "${POT_CACHE}/$_filename" | zfs recv "${POT_ZFS_ROOT}/jails/$_pname"
+		# shellcheck disable=SC2046
+		xzcat "${POT_CACHE}/$_filename" | zfs receive \
+		  $(_get_zfs_receive_extra_args) "${POT_ZFS_ROOT}/jails/$_pname"
 	fi
-
-	# xzcat  "${POT_CACHE}/$_filename" | zfs recv -u ${POT_ZFS_ROOT}/jails/$_pname
-	# zfs set mountpoint=${POT_FS_ROOT}/jails/$_rpname
-	# zfs set to be repeated for all children or zfs mount
 
 	# pot.conf modifications
 	_hostname="${_pname}.$( hostname )"


### PR DESCRIPTION
This makes sure that pot running on an encrypted parent fs will
also be encrypted by inheriting the property.

This is implemented in a way that should be backwards compatible
on ZFS versions not supporting the encryption property.

New common function _is_zfs_property_supported implemented so
that it is multi-purpose.