### PR TITLE
Improve Nomad integration and non-persistent behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - attribute no-tmpfs: an attribute, for single dataset only, to not use tmpfs for /tmp
 - create/import: inherit ZFS encryption property from parent filesystem (#196)
 - attribute no-etchosts: an attribute, to not inject additional /etc/hosts entries from `potnet`
+- last-run-stats: new command to get statistics on the last run of a pot, currently contains "ExitCode", which is the exit code of pot.cmd (#200)
+- start: return with code 125 in case pot.cmd of a non-persistent pot failed (#200)
 
 ### Changed
 - Stop logging trivial commands like get-rss to syslog by default (#190)
 - get-rss: test if the pot is running, instead of it only exists during input validation
 - mount-in: mountpoint cannot contain spaces anymore (#187)
+- start: allow pots to run for less than 5 seconds (#200)
+- start: always stop and cleanup non-persistent pots once pot.cmd finished, prevents stray background tasks from keeping them alive (#200)
+- prune: add flag "-g" to delay pruning of pots that just stopped, so users have a chance to inspect last-run-stats (#200)
+
+### Fixed
+- start: correct invocation of prestart and poststart hooks (#200)
 
 ## [0.14.0] 2021-10-31
 ### Added

--- a/bin/pot
+++ b/bin/pot
@@ -137,7 +137,7 @@ Commands:
 	import -- Import a pot from a file or a URL
 	prepare -- Import and prepare a pot - designed for jail orchestrator
 	update-config -- Update the configuration of a pot
-	last-run-stats -- Get statistics about a pots last run
+	last-run-stats -- Get statistics about a pot's last run
 EOF
 }
 

--- a/bin/pot
+++ b/bin/pot
@@ -137,6 +137,7 @@ Commands:
 	import -- Import a pot from a file or a URL
 	prepare -- Import and prepare a pot - designed for jail orchestrator
 	update-config -- Update the configuration of a pot
+	last-run-stats -- Get statistics about a pots last run
 EOF
 }
 
@@ -191,7 +192,8 @@ case "${CMD}" in
 	export-ports|set-attribute|get-attribute|\
 	start|stop|term|\
 	rename|clone|clone-fscomp|promote|\
-	snapshot|revert|purge-snapshots|update-config)
+	snapshot|revert|purge-snapshots|update-config|\
+	last-run-stats)
 		pot-cmd "${CMD}" "$@"
 		exit $?
 		;;

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -1067,7 +1067,7 @@ pot-cmd()
 				lockf -k /tmp/pot-lock-file "$_POT_PATHNAME" "$_cmd" "$@"
 			fi
 			;;
-		config|get-attr|get-rss|info|list|ps|show|top)
+		config|get-attr|get-rss|info|last-run-stats|list|ps|show|top)
 			if _is_verbose ; then
 				logger -p "${POT_LOG_FACILITY}".debug -t pot "$_func $*"
 			fi

--- a/share/pot/last-run-stats.sh
+++ b/share/pot/last-run-stats.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# shellcheck disable=SC3033,SC3040,SC3043
+:
+
+last-run-stats-help()
+{
+	echo "pot last-run-stats [-hv] [-p pname]"
+	echo '  -h print this help'
+	echo '  -v verbose'
+	echo '  -p pname: pot name'
+}
+
+pot-last-run-stats()
+{
+	local _pname
+	_pname=""
+	OPTIND=1
+	while getopts "hvp:" _o ; do
+		case "$_o" in
+		h)
+			last-run-stats-help
+			${EXIT} 0
+			;;
+		v)
+			_POT_VERBOSITY=$(( _POT_VERBOSITY + 1))
+			;;
+		p)
+			_pname="$OPTARG"
+			;;
+		*)
+			last-run-stats-help
+			${EXIT} 1
+			;;
+		esac
+	done
+	if [ -z "$_pname" ]; then
+		_error "A pot name is mandatory"
+		last-run-stats-help
+		${EXIT} 1
+	fi
+	if ! _is_pot "$_pname"; then
+		_error "$_pname is not a pot"
+		${EXIT} 1
+	fi
+	_confdir="${POT_FS_ROOT}/jails/$_pname/conf"
+	cat "$_confdir/.last_run_stats" 2>/dev/null || echo "{}"
+}

--- a/share/pot/prune.sh
+++ b/share/pot/prune.sh
@@ -7,42 +7,69 @@ prune-help()
 	echo '  -h print this help'
 	echo '  -v verbose'
 	echo '  -q quite - prune with no output'
+	echo '  -g grace period - do not prune pots that just finished executing'
 	echo '  -n dry-run - do not destroy anything'
 }
 
 # $1 pot name
 _prune_pot()
 {
-	local _pname _quiet _dry_run
+	local _pname _quiet _dry_run _grace_period _confdir
 	_pname=$1
 	_dry_run=$2
 	_quiet=$3
+	_grace_period=$4
+	_confdir="${POT_FS_ROOT}/jails/$_pname/conf"
+
 	if ! _is_pot_running "$_pname" ; then
-		if _is_pot_prunable "$_pname" ; then
-			if [ "$( _get_conf_var "$_pname" "pot.attr.to-be-pruned" )" = "YES" ]; then
-				_info "Pruning $_pname"
-				if [ "$_dry_run" = "YES" ]; then
-					return
-				fi
-				pot-cmd stop "$_pname"
-				if ! pot-cmd destroy -p "$_pname" ; then
-					_qerror "$_quiet" "Error while pruning $_pname"
-				else
-					_info "Pruned $_pname"
-				fi
+		if ! _is_pot_prunable "$_pname" ; then
+			return
+		fi
+		if [ "$( _get_conf_var "$_pname" "pot.attr.to-be-pruned" )" != "YES" ]; then
+			return
+		fi
+		if [ "$_grace_period" = "YES" ]; then
+			# check if just finished running
+			if find "$_confdir/.last_run_stats" -mtime -1m 2>/dev/null | \
+			    grep -q "."; then
+				return
 			fi
+
+			sleep 2 # give pot-start a chance to write .last_run_stats
+
+			# check again if just finished running
+			if find "$_confdir/.last_run_stats" -mtime -1m 2>/dev/null | \
+			    grep -q "."; then
+				return
+			fi
+
+			if _is_pot_running "$_pname" ; then
+				return
+			fi
+		fi
+
+		_info "Pruning $_pname"
+		if [ "$_dry_run" = "YES" ]; then
+			return
+		fi
+		pot-cmd stop "$_pname"
+		if ! pot-cmd destroy -p "$_pname" ; then
+			_qerror "$_quiet" "Error while pruning $_pname"
+		else
+			_info "Pruned $_pname"
 		fi
 	fi
 }
 
 _prune_pots()
 {
-	local _pots _dry_run _quiet _p
+	local _pots _dry_run _quiet _grace_period _p
 	_dry_run="$1"
 	_quiet="$2"
+	_grace_period="$3"
 	_pots="$( _get_pot_list )"
 	for _p in $_pots; do
-		_prune_pot "$_p" "$_dry_run" "$_quiet"
+		_prune_pot "$_p" "$_dry_run" "$_quiet" "$_grace_period"
 	done
 }
 
@@ -50,9 +77,10 @@ pot-prune()
 {
 	local _quiet _dry_run
 	_quiet=
+	_grace_period="NO"
 	_dry_run="NO"
 	OPTIND=1
-	while getopts "hvqn" _o ; do
+	while getopts "hvqgn" _o ; do
 		case "$_o" in
 		h)
 			prune-help
@@ -63,6 +91,9 @@ pot-prune()
 			;;
 		q)
 			_quiet="quiet"
+			;;
+		g)
+			_grace_period="YES"
 			;;
 		n)
 			_dry_run="YES"
@@ -76,5 +107,5 @@ pot-prune()
 	if ! _is_uid0 ; then
 		${EXIT} 1
 	fi
-	_prune_pots "$_dry_run" "$_quiet"
+	_prune_pots "$_dry_run" "$_quiet" "$_grace_period"
 }

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -26,6 +26,10 @@ start-cleanup()
 		return
 	fi
 	if [ -n "$2" ] && _is_valid_netif "${2}a" ; then
+		sleep 1 # try to avoid a race condition in the epair driver,
+			# potentially causing a kernel panic, which should
+			# be fixed in FreeBSD 13.1:
+			# https://cgit.freebsd.org/src/commit/?h=stable/13&id=f4aba8c9f0c
 		ifconfig "${2}a" destroy
 	fi
 	pot-cmd stop "$_pname"

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -550,7 +550,6 @@ _js_start()
 			start-cleanup "$_pname" "${_iface}"
 		fi
 		rm -f "${POT_TMP:-/tmp}/pot_stopped_${_pname}"
-		# store exit_code of process
 
 		if [ "$_exit_code" -ne 0 ]; then
 			# return code to signal application exit error

--- a/share/pot/stop.sh
+++ b/share/pot/stop.sh
@@ -48,7 +48,10 @@ _js_stop()
 		jail -q -r "$_pname"
 		if [ -n "$_epair" ]; then
 			_debug "Remove ${_epair%b}[a|b] network interfaces"
-			sleep 1 # try to avoid a race condition in the epair driver, potentially causing a kernel panic
+			sleep 1 # try to avoid a race condition in the epair driver,
+			        # potentially causing a kernel panic, which should
+			        # be fixed in FreeBSD 13.1:
+			        # https://cgit.freebsd.org/src/commit/?h=stable/13&id=f4aba8c9f0c
 			ifconfig "${_epair%b}"a destroy
 		else
 			if [ "$_network_type" = "alias" ]; then


### PR DESCRIPTION
Motivation was starting to work with Nomad batch jobs and hitting a
couple of problems that made them not so useful, especially:

- Not exit code propagation, so batch jobs were also marked as
  successful.
- Once exit code propagation worked, unnecessary delays due to
  the existing start-up procedure.
- Automatic restarts causing all sorts of problems (life-time
  of pots would overlap and cause issues).

This commit corrects pot itself, another review will be opened
to adapt the nomad-pot-driver making use of these new features.

PR for nomad-pot-driver changes: trivago/nomad-pot-driver#30

Changes in detail:
- start sleep command will now be killed as soon as the actual
  jail command was started, reducing the minimal jail life-time
  (sleep 1234 taken to have a good pkill target).
- once the jail command finishes, its exit_code is written to
  $_confdir/_$pname/conf/.last-run-stats in JSON format.
  This could be extended to be more useful in the future.
- In case of non-persistent jails, pot start returns exit code
  125 if the jail command returned an exit code != 0.
- The content of .last-run-state can be retrieved using the
  new command `pot last-run-state -p potname`.
- A new flag "-g" (for grace period) was added to `pot prune`.
  If set, pots will be pruned only if their .last-run-state was
  written more than a minute ago. This gives processes the
  time to call `pot last-run-stats`.
- Non-persistent jails will also be stopped after the jail command
  returned (will not keep jails alive accidentally like it was
  happening before by left behind processes or by someone
  poking into the jail).
- While there, fixed paths executing prestart and poststart
  scripts.