### PR TITLE
tinirc: Wait for epair on start, set address selection policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - attribute no-etchosts: an attribute, to not inject additional /etc/hosts entries from `potnet`
 - last-run-stats: new command to get statistics on the last run of a pot, currently contains "ExitCode", which is the exit code of pot.cmd (#200)
 - start: return with code 125 in case pot.cmd of a non-persistent pot failed (#200)
+- tinirc: wait for epair interface, exit early if it doesn't become available (#204)
 
 ### Changed
 - Stop logging trivial commands like get-rss to syslog by default (#190)

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -153,8 +153,17 @@ _js_vnet()
 	## if norcscript - write a ad-hoc one
 	if [ "$(_get_conf_var "$_pname" "pot.attr.no-rc-script")" = "YES" ]; then
 		touch "${POT_FS_ROOT}/jails/$_pname/m/tmp/tinirc"
-		echo "ifconfig ${_epairb} inet $_ip netmask $POT_NETMASK" >> "${POT_FS_ROOT}/jails/$_pname/m/tmp/tinirc"
-		echo "route add default $POT_GATEWAY" >> "${POT_FS_ROOT}/jails/$_pname/m/tmp/tinirc"
+		cat >>"${POT_FS_ROOT}/jails/$_pname/m/tmp/tinirc" <<-EOT
+		if ! ifconfig ${_epairb} >/dev/null 2>&1; then
+		    sleep 1
+		    if ! ifconfig ${_epairb} >/dev/null 2>&1; then
+		        >&2 echo "Interface ${_epairb} does not exist"
+		        exit 1
+		    fi
+		fi
+		ifconfig ${_epairb} inet $_ip netmask $POT_NETMASK
+		route add default $POT_GATEWAY
+		EOT
 	else # use rc scripts
 		# set the network configuration in the pot's rc.conf
 		if [ -w "${POT_FS_ROOT}/jails/$_pname/m/etc/rc.conf" ]; then


### PR DESCRIPTION
This applies to pots without an rc script.

Closes #201
