### PR TITLE
tinirc: Configure address selection policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - start: correct invocation of prestart and poststart hooks (#200)
+- tinirc: configure address selection policy (#205)
 
 ## [0.14.0] 2021-10-31
 ### Added


### PR DESCRIPTION
In case of IPv4-only, give IPv4 addresses the highest precedence,
in other cases (IPv6/dual-stack), prefer IPv6 addresses.

This fixes dual-stack tools like ping.

Only implemented for tinirc, as pots running standard rc run
these commands by default.

While there, add "wait for epair" also for IPv6 and private vnet
interfaces.

Fixes #203