### PR TITLE
Label and group interfaces created by pot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - last-run-stats: new command to get statistics on the last run of a pot, currently contains "ExitCode", which is the exit code of pot.cmd (#200)
 - start: return with code 125 in case pot.cmd of a non-persistent pot failed (#200)
 - tinirc: wait for epair interface, exit early if it doesn't become available (#204)
+- ifconfig: label and group interfaces created by pot (#206)
 
 ### Changed
 - Stop logging trivial commands like get-rss to syslog by default (#190)

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -125,7 +125,8 @@ _js_etc_hosts()
 _js_create_epair()
 {
 	local _epair
-	_epair=$(ifconfig epair create)
+	_epair=$(ifconfig epair create descr "$_pname" group "pot")
+
 	if [ -z "${_epair}" ]; then
 		_error "ifconfig epair failed"
 		start-cleanup "$_pname"

--- a/share/pot/vnet-start.sh
+++ b/share/pot/vnet-start.sh
@@ -15,7 +15,7 @@ _public_bridge_start()
 	local _bridge
 	_bridge=$(_pot_bridge)
 	if [ -z "$_bridge" ]; then
-		if _bridge=$(ifconfig bridge create) ; then
+		if _bridge=$(ifconfig bridge create descr "pot public bridge" group "pot") ; then
 			_debug "Bridge created $_bridge"
 		else
 			_error "Bridge not created"
@@ -37,7 +37,7 @@ _private_bridge_start()
 	_bridge_name="$1"
 	_bridge=$(_private_bridge "$_bridge_name")
 	if [ -z "$_bridge" ]; then
-		if _bridge=$(ifconfig bridge create) ; then
+		if _bridge=$(ifconfig bridge create descr "pot private bridge" group "pot") ; then
 			_debug "Bridge created $_bridge"
 		else
 			_error "Bridge not created"
@@ -142,7 +142,7 @@ _ipv6_bridge_start()
 	_bridge=$(_pot_bridge_ipv6)
 
 	if [ -z "$_bridge" ]; then
-		if _bridge=$(ifconfig bridge create) ; then
+		if _bridge=$(ifconfig bridge create descr "pot ipv6 bridge" group "pot") ; then
 			_debug "Bridge created $_bridge"
 		else
 			_error "Bridge not created"


### PR DESCRIPTION
When running a large number of pots, it gets hard to easily figure out which
epair interface was created for which pot, especially when debugging and if
the jail is not running anymore.

This change adds two attributes to all interfaces created by pot:

1. A description, which is the pot name in case pots/epair interfaces and
   the bridge's purpose in case of bridges.
2. The group "pot"

With the change, it's easy to find interfaces belonging to pot

    $ ifconfig -g pot
    bridge0
    epair2a
    epair3a
    epair4a
    epair5a
    epair6a
    epair7a
    epair8a
    epair9a

and also easier to figure out what their purpose is

    $ ifconfig bridge0 | grep -B1 descr
    bridge0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0...
        description: pot public bridge

    $ ifconfig epair2a
    epair2a: flags=8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> ...
            description: my-pot_96958fcf_1401fde2-d6e9-f12e-9c19-08baf0195561
            options=8<VLAN_MTU>
            ether 02:5d:2b:d4:4e:0a
            groups: epair pot
            media: Ethernet 10Gbase-T (10Gbase-T <full-duplex>)
            status: active
            nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>

    $ ifconfig -g pot | xargs -n1 ifconfig | grep -B1 my-pot
    epair2a: flags=8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> ...
            description: my-pot_96958fcf_1401fde2-d6e9-f12e-9c19-08baf0195561

The information contained in descriptions/groups could also be taken advantage
of when developing a more robust `pot stop` procedure.