### PR TITLE
Pot usage message spring cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - start: allow pots to run for less than 5 seconds (#200)
 - start: always stop and cleanup non-persistent pots once pot.cmd finished, prevents stray background tasks from keeping them alive (#200)
 - prune: add flag "-g" to delay pruning of pots that just stopped, so users have a chance to inspect last-run-stats (#200)
+- help: rework usage screens (#209)
 
 ### Fixed
 - start: correct invocation of prestart and poststart hooks (#200)

--- a/bin/pot
+++ b/bin/pot
@@ -89,56 +89,56 @@ if [ -r "$_POT_ETC/pot.conf" ]; then
 fi
 
 usage() {
-	cat << EOF
-Usage: pot command [options]
+	cat <<-"EOF"
+	Usage: pot command [options]
 
-Commands:
-	help	-- Show help
-	version -- Show the pot version
-	config  -- Show pot framework configuration
-	ls/list	-- List of the installed pots
-	show	-- Show pot information
-	info    -- Print minimal information on a pot
-	top     -- Run the unix top in the pot
-	ps      -- Show running pots
-	init	-- Initialize the ZFS layout
-	de-init	-- Deinstall pot from your system
-	vnet-start -- Start the vnet configuration
-	create-base	-- Create a new base image
-	create-fscomp -- Create a new fs component
-	create-private-bridge -- Create a new private bridge
-	create -- Create a new pot (jail)
-	clone -- Clone a pot creating a new one
-	clone-fscomp - Clone a fscomp
-	rename -- Rename a pot
-	destroy -- Destroy a pot
-	prune   -- Destroy not running prunable pots
-	copy-in -- Copy a file or a directory into a pot
-	copy-out -- Copy a file or a directory from a pot
-	mount-in -- Mount a directory, a zfs dataset or a fscomp into a pot
-	add-dep -- Add a dependency
-	set-rss -- Set a resource constraint
-	get-rss -- Get the current resource usage
-	set-cmd -- Set the command to start the pot
-	set-env -- Set environment variabls inside a pot
-	set-hosts -- Set etc/hosts entries inside a pot
-	set-hook -- Set hook scripts for a pot
-	set-attr -- Set a pot's attribute
-	get-attr -- Get a pot's attribute
-	export-ports -- Let export tcp ports
-	start -- Start a jail (pot)
-	stop -- Stop a jail (pot)
-	term -- Start a terminal in a pot
-	run -- Start and open a terminal in a pot
-	snap/snapshot -- Take a snapshot of a pot
-	rollback/revert -- Restore the last snapshot
-	purge-snapshots -- Remove old/all snapshots
-	export -- Export a pot to a file
-	import -- Import a pot from a file or a URL
-	prepare -- Import and prepare a pot - designed for jail orchestrator
-	update-config -- Update the configuration of a pot
-	last-run-stats -- Get statistics about a pot's last run
-EOF
+	Commands:
+	    help    -- Show help
+	    version -- Show version of the pot command
+	    config  -- Show pot framework configuration
+	    ls/list -- List of the installed pots
+	    show    -- Show information on pots
+	    info    -- Print minimal information on a pot
+	    top     -- Run top(1) inside the pot
+	    ps      -- Show running pots
+	    init    -- Initialize the ZFS layout
+	    de-init -- Remove pot from your system
+	    vnet-start -- Start vnet configuration
+	    create-base -- Create a new base image
+	    create-fscomp -- Create a new fs component
+	    create-private-bridge -- Create a new private bridge
+	    create -- Create a new pot (jail)
+	    clone -- Clone a pot, creating a new one
+	    clone-fscomp -- Clone an fscomp
+	    rename -- Rename a pot
+	    destroy -- Destroy a pot
+	    prune   -- Destroy non-running, prunable pots
+	    copy-in -- Copy a file or a directory into a pot
+	    copy-out -- Copy a file or a directory out of a pot
+	    mount-in -- Mount directory, ZFS dataset, or fscomp into a pot
+	    add-dep -- Add a dependency
+	    set-rss -- Set a resource constraint
+	    get-rss -- Get the current resource usage
+	    set-cmd -- Set the command to start the pot
+	    set-env -- Set environment variables inside a pot
+	    set-hosts -- Set /etc/hosts entries inside a pot
+	    set-hook -- Set hook scripts for a pot
+	    set-attribute/set-attr -- Set an attribute on a pot
+	    get-attribute/set-attr -- Get an attribute from a pot
+	    export-ports -- Allows exposing tcp and udp ports
+	    start -- Start a pot (jail)
+	    stop -- Stop a pot (jail)
+	    term -- Open terminal inside of a pot
+	    run -- Same as term, but start pot if it is not running
+	    snap/snapshot -- Take a snapshot of a pot
+	    rollback/revert -- Restore the latest snapshot
+	    purge-snapshots -- Remove old/all snapshots
+	    export -- Export a pot to a file
+	    import -- Import a pot from a file or a URL
+	    prepare -- Import and prepare a pot, used by orchestrators
+	    update-config -- Update the configuration of a pot
+	    last-run-stats -- Get statistics about a pot's last run
+	EOF
 }
 
 # shellcheck disable=SC2034

--- a/share/pot/add-dep.sh
+++ b/share/pot/add-dep.sh
@@ -4,11 +4,14 @@
 
 add-dep-help()
 {
-	echo "pot add-dep [-hv] -p pot -P depPot"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the working pot'
-	echo '  -P depPot : the pot to run before '
+	cat <<-"EOH"
+	pot add-dep [-hv] -p potname -P depPot
+	  -h print this help
+	  -v verbose
+	  -p potname : the working pot
+	  -P depPot : the pot to depend on. Will be started automatically
+	              before starting the working pot "potname".
+	EOH
 }
 
 # $1 pot

--- a/share/pot/clone-fscomp.sh
+++ b/share/pot/clone-fscomp.sh
@@ -4,11 +4,13 @@
 
 clone-fscomp-help()
 {
-	echo "pot clone-fscomp [-hv] -f fscomp -F fscomp"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -F fscomp : the fscomp to be cloned (mandatory)'
-	echo '  -f fscomp : the fscomp name (mandatory)'
+	cat <<-"EOH"
+	pot clone-fscomp [-hv] -f fscomp -F fscomp
+	  -h print this help
+	  -v verbose
+	  -F fscomp : the fscomp to be cloned (mandatory)
+	  -f fscomp : the fscomp name (mandatory)
+	EOH
 }
 
 # $1 new fscomp name

--- a/share/pot/clone.sh
+++ b/share/pot/clone.sh
@@ -7,24 +7,26 @@ _set_pipefail
 
 clone-help()
 {
-	echo "pot clone [-hvF] -p potname -P basepot [-i ipaddr]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -k keep the pot, if clone fails'
-	echo '  -P potname : the pot to be cloned (template)'
-	echo '  -s snapshot : the snapshot to be used to clone'
-	echo '  -p potname : the new pot name'
-	echo '  -f flavour : flavour to be used'
-	echo '  -N network-type : new network type of the cloned pot'
-	echo '  -i ipaddr : an ip address or the keyword auto (if applicable)'
-	echo '  -B bridge-name : the name of the bridge to be used (private-bridge only)'
-	echo '  -S network-stack : the network stack (ipv4, ipv6 or dual)'
-	echo '  -d dns : change dns resolver to one of:'
-	echo '           inherit       - inherit from jailhost (default)'
-	echo '           pot           - the pot configured in POT_DNS_NAME'
-	echo '           custom:<file> - copy <file> into pot configuration'
-	echo '           off           - leave resolver config unaltered'
-	echo '  -F : automatically take snapshots of dataset that has no one'
+	cat <<-"EOH"
+	pot clone [-hvF] -p potname -P basepot [-i ipaddr]
+	  -h print this help
+	  -v verbose
+	  -k keep the pot, if clone fails
+	  -P potname : the pot to be cloned (template)
+	  -s snapshot : the snapshot to be used to clone
+	  -p potname : the name of the pot that is created
+	  -f flavour : flavour to be used
+	  -N network-type : new network type of the cloned pot
+	  -i ipaddr : an ip address or the keyword auto (if applicable)
+	  -B bridge-name : the name of the private bridge to be used
+	  -S network-stack : the network stack (ipv4, ipv6 or dual)
+	  -d dns : change pot dns resolver configuration, one of
+	           inherit       - inherit from jailhost
+	           pot           - the pot configured in POT_DNS_NAME
+	           custom:<file> - copy <file> into pot configuration
+	           off           - leave resolver config unaltered
+	  -F : automatically take snapshots of dataset that has none
+	EOH
 }
 
 # $1 pot name

--- a/share/pot/config.sh
+++ b/share/pot/config.sh
@@ -5,12 +5,14 @@
 
 config-help()
 {
-	echo 'pot config [-h][-v][-q] [-g name ]'
-	echo '  -h -- print this help'
-	echo '  -v verbose'
-	echo '  -q quiet'
-	echo '  -g name : get name value'
-	echo '    '"possible names are $_config_names"
+	cat <<-EOH
+	pot config [-hvq] [-g name]
+	  -h print this help
+	  -v verbose
+	  -q quiet
+	  -g name : get value of config item "name", one of:
+	$(echo "$_config_names" | xargs -n1 echo "     +" | sort)
+	EOH
 }
 
 # $1 quiet

--- a/share/pot/copy-in.sh
+++ b/share/pot/copy-in.sh
@@ -4,14 +4,18 @@
 
 copy-in-help()
 {
-	echo "pot copy-in [-hv] -p pot -s source -d destination"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -F force copy operation for running jails (can partially expose the host file system)'
-	echo '  -p pot : the working pot'
-	echo '  -s source : the file or directory to be copied in'
-	echo '  -d destination : the final location inside the pot'
-	echo '  -c create missing path components to dirname(destination) inside the pot'
+	cat <<-"EOH"
+	pot copy-in [-hv] -p pot -s source -d dest
+	  -h print this help
+	  -v verbose
+	  -F force copy operation for running jails
+	     (WARNING: can expose parts of the host file system)
+	  -p pot : the working pot
+	  -s source : the file or directory to be copied in
+	  -d dest : the final location inside the pot
+	  -c create any missing path components to `dirname destination`
+	     inside the pot
+	EOH
 }
 
 # $1 source

--- a/share/pot/copy-out.sh
+++ b/share/pot/copy-out.sh
@@ -4,13 +4,16 @@
 
 copy-out-help()
 {
-	echo "pot copy-out [-hv] -p pot -s source -d destination"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -F force copy operation for running jails (can partially expose the host file system)'
-	echo '  -p pot : the working pot'
-	echo '  -s source : the file or directory inside the pot'
-	echo '  -d destination : the location (directory) outside the pot to copy the source'
+	cat <<-"EOH"
+	pot copy-out [-hv] -p pot -s source -d dest
+	  -h print this help
+	  -v verbose
+	  -F force copy operation for running jails
+	     (warning: can expose parts of the host file system)
+	  -p pot : the working pot
+	  -s source : the file or directory inside the pot
+	  -d dest : the location (directory) on the host to copy-out to
+	EOH
 }
 
 # $1 source

--- a/share/pot/create-base.sh
+++ b/share/pot/create-base.sh
@@ -6,11 +6,14 @@
 
 create-base-help()
 {
-	echo "pot create-base [-h] [-r RELEASE] [-b basename]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -r RELEASE : supported release are:'"$( _get_valid_releases )"
-	echo '  -b base name : optional, (default: the release)'
+	cat <<-EOH
+	pot create-base [-h] [-r RELEASE] [-b basename]
+	  -h print this help
+	  -v verbose
+	  -r RELEASE : supported release are: $( _get_valid_releases )
+	$( _get_valid_releases | xargs -n1 echo "     +" | sort)
+	  -b basename : optional, (default: the release)
+	EOH
 }
 
 # $1 base name

--- a/share/pot/create-fscomp.sh
+++ b/share/pot/create-fscomp.sh
@@ -4,10 +4,12 @@
 
 create-fscomp-help()
 {
-	echo "pot create-fscomp [-hv] -f name"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -f name : the fs component name (mandatory)'
+	cat <<-"EOH"
+	pot create-fscomp [-hv] -f name
+	  -h print this help
+	  -v verbose
+	  -f name : the fs component name (mandatory)
+	EOH
 }
 
 pot-create-fscomp()

--- a/share/pot/create-private-bridge.sh
+++ b/share/pot/create-private-bridge.sh
@@ -4,11 +4,13 @@
 
 create-private-bridge-help()
 {
-	echo 'pot create-private-bridge [-h][-v][-B name][-S size]'
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -B bridge name'
-	echo '  -S bridge size (number of host expected)'
+	cat <<-"EOH"
+	pot create-private-bridge [-hv] [-B name] [-S size]
+	  -h print this help
+	  -v verbose
+	  -B bridge name
+	  -S bridge size (number of host expected)
+	EOH
 }
 
 # $1 bridge-name

--- a/share/pot/create.sh
+++ b/share/pot/create.sh
@@ -7,34 +7,41 @@ _set_pipefail
 
 create-help()
 {
-	echo "pot create [-hv] -p potname [-N network-type] [-i ipaddr] [-l lvl] [-f flavour]"
-	echo '  [-b base | -P basepot ] [-d dns] [-t type]'
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -k keep the pot, if create fails'
-	echo '  -p potname : the pot name (mandatory)'
-	echo '  -l lvl : pot level (only for type multi)'
-	echo '  -b base : the base pot'
-	echo '  -P pot : the pot to be used as reference'
-	echo '  -d dns : change dns resolver to one of:'
-	echo '           inherit       - inherit from jailhost (default)'
-	echo '           pot           - the pot configured in POT_DNS_NAME'
-	echo '           custom:<file> - copy <file> into pot configuration'
-	echo '           off           - leave resolver config unaltered'
-	echo '  -f flavour : flavour to be used'
-	echo '  -t type: single or multi (default multi)'
-	echo '         single: the pot is based on a unique ZFS dataset'
-	echo '         multi: the pot is composed by a classical collection of 3 ZFS dataset'
-	echo '  -N network-type: one of those'
-	echo '         inherit: inherit the host network stack (default)'
-	echo '         alias: use a static ip as alias configured directly to the host NIC'
-	echo '         public-bridge: use the internal commonly public bridge'
-	echo '         private-bridge: use an internal private bridge (with option -B)'
-	echo '  -i ipaddr : an ip address or the keyword auto (if compatible with the network-type)'
-	echo '         auto: usable with public-bridge and private-bridge (default)'
-	echo '         ipaddr: mandatory with alias, usable with public-bridge and private-bridge'
-	echo '  -B bridge-name : the name of the bridge to be used (private-bridge only)'
-	echo '  -S network-stack : the network stack (ipv4, ipv6 or dual)'
+	cat <<-"EOH"
+	pot create [-hv] -p potname [-N network-type] [-i ipaddr]
+	           [-l lvl] [-f flavour] [-b base|-P basepot]
+	           [-d dns] [-t type]
+	  -h print this help
+	  -v verbose
+	  -k keep the pot, if create fails
+	  -p potname : the pot name (mandatory)
+	  -l lvl : pot level (only for type multi)
+	  -b base : the base pot
+	  -P pot : the pot to be used as reference
+	  -d dns : pot dns resolver configuration, one of
+	           inherit*       - inherit from jailhost (*default)
+	           pot            - the pot configured in POT_DNS_NAME
+	           custom:<file>  - copy <file> into pot configuration
+	           off            - leave resolver config unaltered
+	  -f flavour : flavour to be used
+	  -t type: pot file system layout, one of
+	           single         - the pot is based on a unique ZFS dataset
+	           multi*         - the pot is composed by a classical
+	                            collection of 3 ZFS datasets (*default)
+	  -N network-type: pot network layout, one of
+	           inherit*       - inherit the host network stack (*default)
+	           alias          - configure a static ip alias directly on
+	                            the host's NIC
+	           public-bridge  - use the common internal public bridge
+	           private-bridge - use an internal private bridge (with -B)
+	  -i ipaddr : IP address selection, one of
+	           auto*          - automatically assign address (*default),
+	                            only works with (public|private)-bridge
+	           ipaddr         - mandatory with alias,
+	                            also works with (public|private)-bridge
+	  -B bridge-name : the name of the private bridge to be used
+	  -S network-stack : the network stack (ipv4, ipv6 or dual)
+	EOH
 }
 
 _cj_undo_create()

--- a/share/pot/de-init.sh
+++ b/share/pot/de-init.sh
@@ -4,10 +4,12 @@
 
 de-init-help()
 {
-	echo 'pot de-init [-h][-v][-f]'
-	echo '  -h -- print this help'
-	echo '  -v verbose'
-	echo '  -f force - stop all running pots'
+	cat <<-"EOH"
+	pot de-init [-hvf]
+	  -h print this help
+	  -v verbose
+	  -f force : stop all running pots
+	EOH
 }
 
 pot-de-init()

--- a/share/pot/destroy.sh
+++ b/share/pot/destroy.sh
@@ -4,16 +4,18 @@
 
 destroy-help()
 {
-	echo "pot destroy [-hvFr] [-p potname|-b basename|-f fscomp|-B bridge]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -q quiet'
-	echo '  -F force the stop and destroy'
-	echo '  -p potname : the pot name (mandatory)'
-	echo '  -b basename : the base name (mandatory)'
-	echo '  -f fscomp : the fscomp name (mandatory)'
-	echo '  -B bridge-name : the name of the bridge to be deleted (mandatory)'
-	echo '  -r : destroy recursively all pots based on this base/pot'
+	cat <<-"EOH"
+	pot destroy [-hvFr] [-p potname|-b basename|-f fscomp|-B bridge]
+	  -h print this help
+	  -v verbose
+	  -q quiet
+	  -F force the stop and destroy
+	  -p potname : the pot name (mandatory)
+	  -b basename : the base name (mandatory)
+	  -f fscomp : the fscomp name (mandatory)
+	  -B bridge-name : the name of the bridge to be deleted (mandatory)
+	  -r : destroy recursively all pots based on this base/pot
+	EOH
 }
 
 # $1 zfs dataset

--- a/share/pot/export-ports.sh
+++ b/share/pot/export-ports.sh
@@ -4,17 +4,25 @@
 
 export-ports-help()
 {
-	echo "pot export-ports configure the pot export ports - network type public-bridge only"
-	echo "pot export-ports [-hv] -p pot [-S] -e port ..."
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the working pot'
-	echo '  -e port : the tcp port'
-	echo '            This option can be repeated multiple time, to export more ports'
-	echo '            -e 80 will export tcp port 80 using an available port'
-	echo '            -e 80:30000 will export tcp port 80 using port 30000'
-	echo '            -e tcp:80:30000 will export tcp port 80 using port 30000'
-	echo '            -e udp:53:30053 will export udp port 53 using port 30053'
+	cat <<-"EOH"
+	pot export-ports configure exported ports - public-bridge only
+	pot export-ports [-hv] -p pot [-S] -e [proto:]port[:pot_port] ...
+	  -h print this help
+	  -v verbose
+	  -p pot : the working pot
+	  -e [proto:]port[:pot_port] : port(s) to export
+	         proto can be tcp (default) or udp
+	         port is the port to export
+	         pot_port : a static port to NAT to inside the pot
+	                    dynamically allocated by default
+	         This option can be repeated to export multiple ports.
+
+	     Examples:
+	       -e 80            export proto tcp port 80 to a dynamic port
+	       -e 80:30000      export proto tcp port 80 to pot_port 30000
+	       -e tcp:80:30000  export proto tcp port 80 to pot_port 30000
+	       -e udp:53:30053  export proto udp port 53 to pot_port 30053
+	EOH
 }
 
 # $1 pot

--- a/share/pot/export.sh
+++ b/share/pot/export.sh
@@ -7,17 +7,21 @@
 # Add a way to change compression utility
 
 export-help() {
-	echo "pot export [-hv] -p pot [-s snapshot] [-t tag] [-D directory] [-l level]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the working pot'
-	echo '  -t tag : the tag to be used as suffix in the filename'
-	echo '           if no tag is specified, tha snapshot will be used as suffix'
-	echo '  -c : Treat tags as versions and check if they are decreasing'
-	echo '  -D directory : where to store the compressed file with the pot'
-	echo '  -l compression-level : from 0 (fast) to 9 (best). Defaul level 6. (man xz for more information)'
-	echo '  -F : force exports of multiple snapshot (only 1 snapshot should be allowed)'
-	echo '  -A : auto-fix snapshots number (exactly 1 snapshot is allowed)'
+	cat <<-"EOH"
+	pot export [-hv] -p pot [-s snapshot] [-t tag] [-D dir] [-l level]
+	  -h print this help
+	  -v verbose
+	  -p pot : the working pot
+	  -t tag : the tag to be used as suffix in the filename
+	           if not specified, the snapshot name will be used as suffix
+	  -c : treat tags as versions and check if they are decreasing
+	  -D dir : where to store the compressed file with the pot
+	  -l level : compression level from 0 (fast) to 9 (best).
+	             Default level 6. (see `man xz` for more information)
+	  -F : force export of multiple snapshot
+	       (by default, only one snapshot is allowed)
+	  -A : auto-fix number of snapshots (only one snapshot is allowed)
+	EOH
 }
 
 # $1 : pot name

--- a/share/pot/get-attribute.sh
+++ b/share/pot/get-attribute.sh
@@ -2,15 +2,18 @@
 # shellcheck disable=SC3033,SC3040,SC3043
 :
 
-get-attr-help()
+get-attribute-help()
 {
-	echo "pot get-attr [-hvq] -p pot -A attr"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -q quiet'
-	echo '  -p pot : the working pot'
-	echo '  -A attribute : one of those attributes:'
-	echo '      '"$_POT_RW_ATTRIBUTES $_POT_RO_ATTRIBUTES"
+	cat <<-EOH
+	pot get-attribute [-hvq] -p pot -A attribute
+	  -h print this help
+	  -v verbose
+	  -q quiet
+	  -p pot : the working pot
+	  -A attribute : get value of attribute, one of
+	$(echo "$_POT_RW_ATTRIBUTES $_POT_RO_ATTRIBUTES" |
+	  xargs -n1 echo "     +" | sort)
+	EOH
 }
 
 pot-get-attribute()
@@ -24,7 +27,7 @@ pot-get-attribute()
 	while getopts "hvqp:A:V:" _o ; do
 		case "$_o" in
 		h)
-			get-attr-help
+			get-attribute-help
 			${EXIT} 0
 			;;
 		v)
@@ -40,32 +43,32 @@ pot-get-attribute()
 			_attr="$OPTARG"
 			;;
 		*)
-			get-attr-help
+			get-attribute-help
 			${EXIT} 1
 		esac
 	done
 
 	if [ -z "$_pname" ]; then
 		_error "A pot name is mandatory"
-		get-attr-help
+		get-attribute-help
 		${EXIT} 1
 	fi
 	if [ -z "$_attr" ]; then
 		_error "Option -A is mandatory"
-		get-attr-help
+		get-attribute-help
 		${EXIT} 1
 	fi
 	if ! _is_pot "$_pname" "$_quiet" ; then
 		if [ "$_quiet" != "quiet" ]; then
 			_error "$_pname is not a valid pot"
-			get-attr-help
+			get-attribute-help
 		fi
 		${EXIT} 1
 	fi
 	# shellcheck disable=SC2086
 	if ! _is_in_list "$_attr" $_POT_RW_ATTRIBUTES $_POT_RO_ATTRIBUTES $_POT_JAIL_RW_ATTRIBUTES ; then
 		_error "$_attr is not a valid attribute"
-		get-attr-help
+		get-attribute-help
 		${EXIT} 1
 	fi
 	_value=$(_get_conf_var "$_pname" "pot.attr.$_attr")

--- a/share/pot/get-rss.sh
+++ b/share/pot/get-rss.sh
@@ -4,11 +4,13 @@
 
 get-rss-help()
 {
-	echo "pot get-rss [-h] [-p pot|-a]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the working pot'
-	echo '  -J : output in JSON'
+	cat <<-"EOH"
+	pot get-rss [-h] -p pot
+	  -h print this help
+	  -v verbose
+	  -p pot : the working pot
+	  -J : output in JSON format
+	EOH
 }
 
 # $1 pot name
@@ -66,7 +68,7 @@ pot-get-rss()
 		esac
 	done
 	if [ -z "$_pname" ]; then
-		_error "A pot name or -a are mandatory"
+		_error "A pot name is mandatory"
 		get-rss-help
 		${EXIT} 1
 	fi

--- a/share/pot/help.sh
+++ b/share/pot/help.sh
@@ -13,9 +13,18 @@ pot-help()
 		rollback)
 			_cmd=revert
 			;;
+		run)
+			_cmd=term
+			;;
 		snap)
 			_cmd=snapshot
 			;;
+		set-attr)
+			_cmd=set-attribute
+			;;
+		get-attr)
+			_cmd=get-attribute
+		;;
 	esac
 	if [ ! -r "${_POT_INCLUDE}/${_cmd}.sh" ]; then
 		_error "Command ${_cmd} unkown"

--- a/share/pot/import.sh
+++ b/share/pot/import.sh
@@ -7,12 +7,14 @@
 # add fscomp.conf management
 
 import-help() {
-	echo "pot import [-hv] -p pot -t tag -U URL"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the remote pot name'
-	echo '  -t tag : the tag of the pot'
-	echo '  -U URL : the base URL where to find the image file'
+	cat <<-"EOH"
+	pot import [-hv] -p pot -t tag -U URL
+	  -h print this help
+	  -v verbose
+	  -p pot : the remote pot name
+	  -t tag : the tag of the pot
+	  -U URL : the base URL where to find the image file
+	EOH
 }
 
 # $1 : remote pot name

--- a/share/pot/info.sh
+++ b/share/pot/info.sh
@@ -4,15 +4,17 @@
 
 info-help()
 {
-	echo "pot info [-hvqr] [-p pname|-B bname]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -q quiet'
-	echo '  -p pname: pot name'
-	echo '  -B bname: bridge name'
-	echo '  -r check only if the pot is running'
-	echo '  -E print few pot information as environment variables'
-	echo '  -s list the available snapshots for the pot'
+	cat <<-"EOH"
+	pot info [-hvqr] [-p pname|-B bname]
+	  -h print this help
+	  -v verbose
+	  -q quiet
+	  -p pname : pot name
+	  -B bname : bridge name
+	  -r check only if the pot is running
+	  -E output some pot information as environment variables
+	  -s list the available snapshots for the pot
+	EOH
 }
 
 # $! pot name

--- a/share/pot/init.sh
+++ b/share/pot/init.sh
@@ -7,11 +7,13 @@
 
 init-help()
 {
-	echo 'pot init [-h][-v] [-f pf_file]'
-	echo '  -f pf_file : write pot anchors to this file (empty to skip),'
-	echo '     defaults to result of "sysrc -n pf_rules"'
-	echo '  -h print this help'
-	echo '  -v verbose'
+	cat <<-"EOH"
+	pot init [-hv] [-f pf_file]
+	  -f pf_file : write pot anchors to this file (empty to skip),
+	               defaults to result of `sysrc -n pf_rules`
+	  -h print this help
+	  -v verbose
+	EOH
 }
 
 pot-init()

--- a/share/pot/last-run-stats.sh
+++ b/share/pot/last-run-stats.sh
@@ -4,10 +4,12 @@
 
 last-run-stats-help()
 {
-	echo "pot last-run-stats [-hv] [-p pname]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pname: pot name'
+	cat <<-"EOH"
+	pot last-run-stats [-hv] [-p pname]
+	  -h print this help
+	  -v verbose
+	  -p pname : pot name
+	EOH
 }
 
 pot-last-run-stats()

--- a/share/pot/list.sh
+++ b/share/pot/list.sh
@@ -4,16 +4,18 @@
 
 list-help()
 {
-	echo "pot list [-hpbfFa][-qv]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -q quiet'
-	echo '  -p list pots (default)'
-	echo '  -b list bases instead of pots'
-	echo '  -f list fs components instead of pots'
-	echo '  -F list available flavours'
-	echo '  -B list available bridges (newtork type)'
-	echo '  -a list everything (-q not compatible)'
+	cat <<-"EOH"
+	pot list [-hpbfFa] [-qv]
+	  -h print this help
+	  -v verbose
+	  -q quiet
+	  -p list pots (default)
+	  -b list bases instead of pots
+	  -f list fs components instead of pots
+	  -F list available flavours
+	  -B list available bridges (network type)
+	  -a list everything (incompatible with -q)
+	EOH
 }
 
 # $1 pot name

--- a/share/pot/mount-in.sh
+++ b/share/pot/mount-in.sh
@@ -4,16 +4,20 @@
 
 mount-in-help()
 {
-	echo "pot mount-in [-hvwr] -p pot -m mnt -f fscomp | -d directory | -z dataset"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the working pot'
-	echo '  -f fscomp : the fs component to be mounted'
-	echo '  -z zfs dataset : the zfs dataset to be mounted'
-	echo '  -d directory : the directory that has to be mounted in the pot (absolute pathname)'
-	echo '  -m mnt : the mount point inside the pot'
-	echo '  -w : '"don't use nullfs, but change the zfs mountpoint [usable only with -z and -f](potentially DANGEROUS)"
-	echo '  -r : mount in read-only'
+	cat <<-"EOH"
+	pot mount-in [-hvwr] -p pot -m mnt -f fscomp|-d dir|-z dataset
+	  -h print this help
+	  -v verbose
+	  -p pot : the working pot
+	  -f fscomp : a fs component to be mounted
+	  -z zfs dataset : a ZFS dataset to be mounted
+	  -d dir : a directory on the host to be mounted,
+	           absolute pathname
+	  -m mnt : the mount point inside of the pot
+	  -w : change the ZFS mount point instead of using nullfs,
+	       potentially DANGEROUS and only usable with -z and -f
+	  -r : mount-in read-only
+	EOH
 }
 
 # $1 pot

--- a/share/pot/mount-out.sh
+++ b/share/pot/mount-out.sh
@@ -4,11 +4,13 @@
 
 mount-out-help()
 {
-	echo "pot mount-out [-hvwr] -p pot -m mnt"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the working pot'
-	echo '  -m mnt : the mount point inside the pot'
+	cat <<-"EOH"
+	pot mount-out [-hvwr] -p pot -m mnt
+	  -h print this help
+	  -v verbose
+	  -p pot : the working pot
+	  -m mnt : the mount point inside the pot
+	EOH
 }
 
 # $1 pot

--- a/share/pot/prepare.sh
+++ b/share/pot/prepare.sh
@@ -4,23 +4,27 @@
 
 prepare-help()
 {
-	echo "pot prepare [-hvS] -p pot -U URL -t tag -a aID -n potname -c cmd"
-	echo '        [-e port] [-N network-type] [-i ipaddr] [-B bridge-name]'
-	echo '  -h print this help'
-	echo '  -h verbose'
-	echo '  -p pot : the pot image'
-	echo '  -U URL : the base URL where to find the image file'
-	echo '  -t tag : the tag of the pot'
-	echo '  -a aID : the allocation ID'
-	echo '  -n potname : the new potname (used instead of pot_tag)'
-	echo '  -c cmd : the command line to start the container'
-	echo '  -N network-type : new network type of the imported pot'
-	echo '  -i ipaddr : an ip address or the keyword auto (if applicable)'
-	echo '  -e port : the tcp port'
-	echo '            This option can be repeated multiple time, to export more ports'
-	echo '  -B bridge-name : the name of the bridge to be used (private-bridge only)'
-	echo '  -S network-stack : the network stack (ipv4, ipv6 or dual)'
-	echo '  -s : start immediately the newly generated pot'
+	cat <<-"EOH"
+	pot prepare [-hvS] -p pot -U URL -t tag -a aID -n potname -c cmd
+	            [-e [proto:]port[:pot_port]] [-N network-type]
+	            [-i ipaddr] [-B bridge-name]
+	  -h print this help
+	  -h verbose
+	  -p pot : the pot image
+	  -U URL : the base URL where to find the image file
+	  -t tag : the tag of the pot
+	  -a aID : the allocation ID
+	  -n potname : the new potname (used instead of pot_tag)
+	  -c cmd : the command line to start the container
+	  -N network-type : new network type of the imported pot
+	  -i ipaddr : an ip address or the keyword auto (if applicable)
+	  -e [proto:]port[:pot_port] : port(s) to export
+	         This option can be repeated to export multiple ports.
+	         See `pot help export-ports` for details.
+	  -B bridge-name : the name of the private bridge to be used
+	  -S network-stack : the network stack (ipv4, ipv6 or dual)
+	  -s : start the newly generated pot immediately
+	EOH
 }
 
 pot-prepare()

--- a/share/pot/prune.sh
+++ b/share/pot/prune.sh
@@ -3,12 +3,14 @@
 
 prune-help()
 {
-	echo "pot prune [-hvq]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -q quite - prune with no output'
-	echo '  -g grace period - do not prune pots that just finished executing'
-	echo '  -n dry-run - do not destroy anything'
+	cat <<-"EOH"
+	pot prune [-hvq]
+	  -h print this help
+	  -v verbose
+	  -q quite - prune with no output
+	  -g grace_period - do not prune pots that just finished executing
+	  -n dry-run - do not destroy anything
+	EOH
 }
 
 # $1 pot name

--- a/share/pot/ps.sh
+++ b/share/pot/ps.sh
@@ -3,10 +3,12 @@
 
 ps-help()
 {
-	echo "pot ps [-hvq]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -q quite: print only active pot'\''s name'
+	cat <<-"EOH"
+	pot ps [-hvq]
+	  -h print this help
+	  -v verbose
+	  -q quiet : only print pot names
+	EOH
 }
 
 # $1 pot name

--- a/share/pot/purge-snapshots.sh
+++ b/share/pot/purge-snapshots.sh
@@ -4,12 +4,14 @@
 
 purge-snapshots-help()
 {
-	echo "pot purge-snapshots [-h][-v][-a] [-p potname|-f fscomp]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p potname : the pot target of the purge-snapshots'
-	echo '  -f fscomp : the fs component target of the purge-snapshots'
-	echo '  -a : remove all snapshot, the last one included'
+	cat <<-"EOH"
+	pot purge-snapshots [-hva] -p potname|-f fscomp
+	  -h print this help
+	  -v verbose
+	  -p potname : the pot target of the purge-snapshots
+	  -f fscomp : the fs component target of the purge-snapshots
+	  -a remove all snapshot, including the latest one
+	EOH
 }
 
 # $1 zfs dataset

--- a/share/pot/rename.sh
+++ b/share/pot/rename.sh
@@ -4,11 +4,13 @@
 
 rename-help()
 {
-	echo "pot rename [-h][-v] -p OldPotName -n NewPotName"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p oldname : the previous pot name'
-	echo '  -n newname : the new pot name'
+	cat <<-"EOH"
+	pot rename [-hv] -p oldname -n newname
+	  -h print this help
+	  -v verbose
+	  -p oldname : the name of an existing pot to rename
+	  -n newname : the new name for an existing pot
+	EOH
 }
 
 _rn_conf()

--- a/share/pot/revert.sh
+++ b/share/pot/revert.sh
@@ -4,11 +4,13 @@
 
 revert-help()
 {
-	echo "pot revert [-hva] -p potname|-f fscomp"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p potname : the pot target of the revert'
-	echo '  -f fscomp : the fs component target of the revert'
+	cat <<-"EOH"
+	pot revert [-hv] -p potname|-f fscomp
+	  -h print this help
+	  -v verbose
+	  -p potname : the pot target of the revert
+	  -f fscomp : the fs component target of the revert
+	EOH
 }
 
 # $1 pot name

--- a/share/pot/set-attribute.sh
+++ b/share/pot/set-attribute.sh
@@ -2,15 +2,17 @@
 # shellcheck disable=SC3033,SC3040,SC3043
 :
 
-set-attr-help()
+set-attribute-help()
 {
-	echo "pot set-attr [-hv] -p pot -A attr -V value"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the working pot'
-	echo '  -A attribute : one of those attributes:'
-	echo '      '"$_POT_RW_ATTRIBUTES"
-	echo '  -V value : the new value for the attribute'
+	cat <<-EOH
+	pot set-attribute [-hv] -p pot -A attr -V value
+	  -h print this help
+	  -v verbose
+	  -p pot : the working pot
+	  -A attribute : one of
+	$(echo "$_POT_RW_ATTRIBUTES" | xargs -n1 echo "     +" | sort)
+	  -V value : the new value for "attribute"
+	EOH
 }
 
 # check if the argument is a valid boolean value
@@ -42,7 +44,7 @@ _set_boolean_attribute()
 	_value=$3
 	if ! _value=$(_normalize_true_false "$_value") ; then
 		_error "value $_value is not a valid boolean value"
-		set-attr-help
+		set-attribute-help
 		return 1
 	fi
 	_cdir="$POT_FS_ROOT/jails/$_pname/conf"
@@ -62,7 +64,7 @@ _set_uint_attribute()
 
 	if [ -n "$(printf '%s' "${_value}" | tr -d '0-9')" ] ; then
 		_error "value $_value is not a valid uint value"
-		set-attr-help
+		set-attribute-help
 		return 1
 	fi
 	_cdir="$POT_FS_ROOT/jails/$_pname/conf"
@@ -87,7 +89,7 @@ pot-set-attribute()
 	while getopts "hvp:A:V:" _o ; do
 		case "$_o" in
 		h)
-			set-attr-help
+			set-attribute-help
 			return 0
 			;;
 		v)
@@ -103,35 +105,35 @@ pot-set-attribute()
 			_attr="$OPTARG"
 			;;
 		*)
-			set-attr-help
+			set-attribute-help
 			return 1
 		esac
 	done
 
 	if [ -z "$_pname" ]; then
 		_error "A pot name is mandatory"
-		set-attr-help
+		set-attribute-help
 		return 1
 	fi
 	if [ -z "$_attr" ]; then
 		_error "Option -A is mandatory"
-		set-attr-help
+		set-attribute-help
 		return 1
 	fi
 	if [ -z "$_value" ]; then
 		_error "Option -V is mandatory"
-		set-attr-help
+		set-attribute-help
 		return 1
 	fi
 	if ! _is_pot "$_pname" ; then
 		_error "$_pname is not a valid pot"
-		set-attr-help
+		set-attribute-help
 		return 1
 	fi
 	# shellcheck disable=SC2086
 	if ! _is_in_list "$_attr" $_POT_RW_ATTRIBUTES ${_POT_JAIL_RW_ATTRIBUTES} ; then
 		_error "$_attr is not a valid attribute"
-		set-attr-help
+		set-attribute-help
 		return 1
 	fi
 	if ! _is_uid0 ; then

--- a/share/pot/set-cmd.sh
+++ b/share/pot/set-cmd.sh
@@ -3,11 +3,13 @@
 :
 
 set-cmd-help() {
-	echo "pot set-cmd [-hv] -p pot -c cmd"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the working pot'
-	echo '  -c cmd : the command line to start the container'
+	cat <<-"EOH"
+	pot set-cmd [-hv] -p pot -c cmd
+	  -h print this help
+	  -v verbose
+	  -p pot : the working pot
+	  -c cmd : the command line to start the container
+	EOH
 }
 
 pot-set-cmd()

--- a/share/pot/set-env.sh
+++ b/share/pot/set-env.sh
@@ -3,12 +3,14 @@
 :
 
 set-env-help() {
-	echo "pot set-env [-hv] -p pot -E env"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the working pot'
-	echo '  -E var=value : the variable and the value to be added'
-	echo '     this option can be repeated more than once'
+	cat <<-"EOH"
+	pot set-env [-hv] -p pot -E env
+	  -h print this help
+	  -v verbose
+	  -p pot : the working pot
+	  -E var=value : the variable and the value to be added
+	     this option can be repeated more than once
+	EOH
 }
 
 # $1 pot

--- a/share/pot/set-hook.sh
+++ b/share/pot/set-hook.sh
@@ -3,14 +3,16 @@
 :
 
 set-hook-help() {
-	echo "pot set-hook [-hv] -p pot [-s hook]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the working pot'
-	echo '  -s hook : the pre-start hook'
-	echo '  -S hook : the post-start hook'
-	echo '  -t hook : the pre-stop hook'
-	echo '  -T hook : the post-stop hook'
+	cat <<-"EOH"
+	pot set-hook [-hv] -p pot [-s hook]
+	  -h print this help
+	  -v verbose
+	  -p pot : the working pot
+	  -s hook : the pre-start hook
+	  -S hook : the post-start hook
+	  -t hook : the pre-stop hook
+	  -T hook : the post-stop hook
+	EOH
 }
 
 # $1 pot

--- a/share/pot/set-hosts.sh
+++ b/share/pot/set-hosts.sh
@@ -3,12 +3,14 @@
 :
 
 set-hosts-help() {
-	echo "pot set-hosts [-hv] -p pot -H env"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the working pot'
-	echo '  -H hostname:IP : the hostname and the ip to be added in the /etc/hosts'
-	echo '     this option can be repeated more than once'
+	cat <<-"EOH"
+	pot set-hosts [-hv] -p pot -H hostname:IP
+	  -h print this help
+	  -v verbose
+	  -p pot : the working pot
+	  -H hostname:IP : hostname-to-IP resolution to be added
+	                   to /etc/hosts, can be used multiple times
+	EOH
 }
 
 # $1 pot

--- a/share/pot/set-rss.sh
+++ b/share/pot/set-rss.sh
@@ -4,12 +4,14 @@
 
 set-rss-help()
 {
-	echo "pot set-rss [-hv] -p pot -C cpus -M memory"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the working pot'
-	echo '  -C cpus : the max amount of CPUs'
-	echo '  -M memory : max memory usable (integer values)'
+	cat <<-"EOH"
+	pot set-rss [-hv] -p pot [-C cpus] [-M memory]
+	  -h print this help
+	  -v verbose
+	  -p pot : the working pot
+	  -C cpus : the max amount of CPUs
+	  -M memory : max memory usable (integer values)
+	EOH
 }
 
 # $1 pot

--- a/share/pot/show.sh
+++ b/share/pot/show.sh
@@ -4,13 +4,15 @@
 
 show-help()
 {
-	echo "pot show [-hvq] [-a|-r|-p potname]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -q quiet'
-	echo '  -a all pots'
-	echo '  -r all running pots (default)'
-	echo '  -p potname select the pot by name'
+	cat <<-"EOH"
+	pot show [-hvq] [-a|-r|-p potname]
+	  -h print this help
+	  -v verbose
+	  -q quiet
+	  -a all pots
+	  -r all running pots (default)
+	  -p potname : select pot by name
+	EOH
 }
 
 # show pot static information

--- a/share/pot/snapshot.sh
+++ b/share/pot/snapshot.sh
@@ -4,12 +4,14 @@
 
 snapshot-help()
 {
-	echo "pot snapshot [-h][-v][-a] [-p potname|-f fscomp]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -r replace the oldest available snapshot with the new one (not compatible with -a)'
-	echo '  -p potname : the pot target of the snapshot'
-	echo '  -f fscomp : the fs component target of the snapshot'
+	cat <<-"EOH"
+	pot snapshot [-hv] -p potname|-f fscomp
+	  -h print this help
+	  -v verbose
+	  -r replace the oldest available snapshot with the new one
+	  -p potname : the pot target of the snapshot
+	  -f fscomp : the fs component target of the snapshot
+	EOH
 }
 
 pot-snapshot()

--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -4,16 +4,20 @@
 
 start-help()
 {
-	echo "pot start [-h] [-p] potname"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -s take a snapshot before to start'
-	echo '     snapshots are identified by the epoch'
-	echo '     all zfs datasets under the jail dataset are considered'
-	echo '  -S take a snapshot before to start [DEPRECATED]'
-	echo '     snapshots are identified by the epoch'
-	echo '     all zfs datasets mounted in rw are considered (full)'
-	echo '  potname : the jail that has to start'
+	cat <<-"EOH"
+	pot start [-h] -p potname [pname]
+	  -h print this help
+	  -v verbose
+	  -s take a snapshot before starting the pot
+	     snapshots are identified by the epoch
+	     all ZFS datasets under the jail dataset are considered
+	  -S take a snapshot before starting the pot [DEPRECATED]
+	     snapshots are identified by the epoch
+	     all ZFS datasets mounted in rw are considered (full)
+	  -p potname : the pot to be started
+
+	  pname : the pot to be started if "-p potname" not given
+	EOH
 }
 
 # $1 pot name

--- a/share/pot/stop.sh
+++ b/share/pot/stop.sh
@@ -4,10 +4,14 @@
 
 stop-help()
 {
-	echo "pot stop [-hv] [-p] potname"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  potname : the pot that has to stop'
+	cat <<-"EOH"
+	pot stop [-hv] -p potname [pname]
+	  -h print this help
+	  -v verbose
+	  -p potname : the pot to be stopped
+
+	  pname : the pot to be stopped if "-p potname" not given
+	EOH
 }
 
 _js_cpu_rebalance()

--- a/share/pot/term.sh
+++ b/share/pot/term.sh
@@ -4,11 +4,16 @@
 
 term-help()
 {
-	echo "pot term [-hvf] [-p] potname"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -f force: it start the pot, if it'\''s not running'
-	echo '  potname : the desired pot'
+	cat <<-"EOH"
+	pot term [-hvf] -p potname [pname]
+	pot run [-hv] -p potname [pname]
+	  -h print this help
+	  -v verbose
+	  -f : start the pot if it is not running
+	  -p potname : the pot to open terminal in
+
+	  pname : pot to open terminal in if "-p potname" not given
+	EOH
 }
 
 # TODO a configurable shell or a login shell

--- a/share/pot/top.sh
+++ b/share/pot/top.sh
@@ -4,9 +4,11 @@
 
 top-help()
 {
-	echo "pot top [-h] -p pot"
-	echo '  -h print this help'
-	echo '  -p pot : the working pot'
+	cat <<-"EOH"
+	pot top [-h] -p pot
+	  -h print this help
+	  -p pot : the working pot
+	EOH
 }
 
 pot-top()

--- a/share/pot/update-config.sh
+++ b/share/pot/update-config.sh
@@ -4,11 +4,13 @@
 
 update-config-help()
 {
-	echo "pot update-config [-h] [-p pot|-a]"
-	echo '  -h print this help'
-	echo '  -v verbose'
-	echo '  -p pot : the working pot'
-	echo '  -a : all the pots'
+	cat <<-"EOH"
+	pot update-config [-h] -p pot|-a
+	  -h print this help
+	  -v verbose
+	  -p pot : the working pot
+	  -a : apply to all pots
+	EOH
 }
 
 # $1 pname

--- a/share/pot/version.sh
+++ b/share/pot/version.sh
@@ -4,10 +4,12 @@
 
 version-help()
 {
-	echo 'pot version [-h][-v][-q]'
-	echo '  -h -- print this help'
-	echo '  -v verbose'
-	echo '  -q quiet'
+	cat <<-"EOH"
+	pot version [-hvq]
+	  -h print this help
+	  -v verbose
+	  -q quiet
+	EOH
 }
 
 

--- a/share/pot/vnet-start.sh
+++ b/share/pot/vnet-start.sh
@@ -4,10 +4,12 @@
 
 vnet-start-help()
 {
-	echo 'pot vnet-start [-h][-v]'
-	echo '  -h -- print this help'
-	echo '  -v verbose'
-	echo '  -B bridge-name (opional)'
+	cat <<-"EOH"
+	pot vnet-start [-hv] [-B bridge-name]
+	  -h print this help
+	  -v verbose
+	  -B bridge-name (optional)
+	EOH
 }
 
 _public_bridge_start()

--- a/tests/set-attr1.sh
+++ b/tests/set-attr1.sh
@@ -9,7 +9,7 @@
 . common-stub.sh
 
 # app specific stubs
-set-attr-help()
+set-attribute-help()
 {
 	__monitor HELP "$@"
 }

--- a/tests/set-attr2.sh
+++ b/tests/set-attr2.sh
@@ -9,7 +9,7 @@
 . common-stub.sh
 
 # app specific stubs
-set-attr-help()
+set-attribute-help()
 {
 	__monitor HELP "$@"
 }


### PR DESCRIPTION
- Use indented heredoc everywhere (makes writing and reading the
  code easier), avoid variable expansion where possible
- Correct minor mistakes in comments
- Correct wording where the need seemed obvious
- Reformat all help messages to fit in a standard terminal
- Fixed a few bugs found while testing all help screens