### PR TITLE
Improve pot prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - tinirc: wait for epair interface, exit early if it doesn't become available (#204)
 - ifconfig: label and group interfaces created by pot (#206)
 - clone: add dns option, to customize DNS configuration while cloning (#199)
+- prepare: add -d option to change dns configuration during clone (#192)
 
 ### Changed
 - Stop logging trivial commands like get-rss to syslog by default (#190)
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - start: always stop and cleanup non-persistent pots once pot.cmd finished, prevents stray background tasks from keeping them alive (#200)
 - prune: add flag "-g" to delay pruning of pots that just stopped, so users have a chance to inspect last-run-stats (#200)
 - help: rework usage screens (#209)
+- prepare: enable attribute no-tmpfs and no-etc-hosts (#192)
 
 ### Fixed
 - start: correct invocation of prestart and poststart hooks (#200)

--- a/share/pot/prepare.sh
+++ b/share/pot/prepare.sh
@@ -195,6 +195,13 @@ pot-prepare()
 	if ! pot-cmd set-attribute -A localhost-tunnel -V YES -p "$_new_pname" ; then
 		_error "Couldn't enable the localhost-tunnel attribute - ignoring"
 	fi
+	if ! pot-cmd set-attribute -A no-etc-hosts -V YES -p "$_new_pname" ; then
+		_error "Couldn't disable the enrichment of /etc/hosts - ignoring"
+	fi
+	if ! pot-cmd set-attribute -A no-tmpfs -V YES -p "$_new_pname" ; then
+		_error "Couldn't disable tmpfs for /tmp - ignoring"
+	fi
+
 	if [ -n "$_ports" ]; then
 		for _p in $_ports ; do
 			_port_args="-e $_p $_port_args"


### PR DESCRIPTION
Follow up on better attribute setup with `pot prepare`.
Additional attribute have been enabled:
* `no-tmpfs` : with many jails, `tmpfs`will use a lot of memory
* `no-etchosts` : in a dynamic environment, the `/etc/hosts`entries with jails running at start time don´t make a lot of sense

While here, `prepare` now expose the `-d` option to change the dns resolver configuration of the imported pot

fix #192 