### PR TITLE
Add start time to .last_run_stats

### DIFF
--- a/share/pot/start.sh
+++ b/share/pot/start.sh
@@ -699,8 +699,9 @@ _js_start()
 
 	wait "$_wait_pid"
 	_exit_code=$?
+	_epoch=$(date +%s)
 
-	echo "{ \"ExitCode\": $_exit_code }" > "$_confdir/.last_run_stats"
+	echo "{ \"ExitCode\": $_exit_code, \"StartedAt\": $_epoch }" > "$_confdir/.last_run_stats"
 
 	if [ "$_persist" = "NO" ]; then
 		rm -f "${POT_TMP:-/tmp}/pot_main_pid_${_pname}"


### PR DESCRIPTION
I was trying something today, and this is to store the started time inside .last_run_stats for future reference when listing pots and finding the uptime of each pod. 

Not sure if this is useful or not, and on the other hand `.last_run_stats ` file was actually meant for things like that